### PR TITLE
[21019] Add requirements.txt file for sustainml_modules Python dependencies

### DIFF
--- a/sustainml_modules/requirements.txt
+++ b/sustainml_modules/requirements.txt
@@ -1,0 +1,13 @@
+PyQt5>=5.15.10
+rdflib>=7.0.0
+torch>=2.1.2+cu121
+numpy>=1.24.1
+Pillow>=9.3.0
+opencv-python>=4.9.0.80
+transformers>=4.37.0
+networkx>=3.0
+ollama
+ultralytics
+optimum
+onnx
+timm


### PR DESCRIPTION
This PR adds the `requirements.txt file` that will contain all the required Python dependencies needed by the `sustainml_modules`