### PR TITLE
[21062] Fix docs typos

### DIFF
--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/apprequirements.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/apprequirements.rst
@@ -110,7 +110,6 @@ User is meant to implement the funcionality of the node within the ``test:callba
         region = user_input.region()
         for byte in user_input.extra_data():
             print(byte)
-        task_id = user_input.task_id()
 
         # Do processing...
 

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/carbontracker.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/carbontracker.rst
@@ -105,7 +105,6 @@ User is meant to implement the funcionality of the node within the ``test:callba
         for input_batch in ml_model.input_batch():
             print(input_batch)
         target_latency = ml_model.target_latency()
-        task_id = ml_model.task_id()
 
         # UserInput
         # (some of the fields are for internal use only and will not be shown here)
@@ -122,7 +121,6 @@ User is meant to implement the funcionality of the node within the ``test:callba
         region = user_input.region()
         for byte in user_input.extra_data():
             print(byte)
-        task_id = user_input.task_id()
 
         # HWResource
         hw_description = hw.hw_description()
@@ -130,14 +128,13 @@ User is meant to implement the funcionality of the node within the ``test:callba
         latency = hw.latency()
         memory_footprint_of_ml_model = hw.memory_footprint_of_ml_model()
         max_hw_memory_footprint = hw.max_hw_memory_footprint()
-        task_id = hw.task_id()
 
         # Do processing...
 
         # Populate carbon footprint output.
         # There is no need to specify node_status for the moment
         # as it will automatically be set to IDLE when the callback returns.
-        co2.carbon_intensity(4)
+        co2.carbon_footprint(4)
         co2.energy_consumption(1000)
         co2.carbon_intesity(2)
 

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwconstraints.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwconstraints.rst
@@ -111,7 +111,6 @@ User is meant to implement the funcionality of the node within the ``test:callba
         region = user_input.region()
         for byte in user_input.extra_data():
             print(byte)
-        task_id = user_input.task_id()
 
         # Do processing...
 

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwprovider.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwprovider.rst
@@ -105,7 +105,6 @@ User is meant to implement the funcionality of the node within the ``test:callba
         for input_batch in ml_model.input_batch():
             print(input_batch)
         target_latency = ml_model.target_latency()
-        task_id = ml_model.task_id()
 
         # Apprequirements
         for requirement in app_requirements.app_requirements():

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/mlmodelmetadata.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/mlmodelmetadata.rst
@@ -107,7 +107,6 @@ User is meant to implement the funcionality of the node within the ``test:callba
         region = user_input.region()
         for byte in user_input.extra_data():
             print(byte)
-        task_id = user_input.task_id()
 
         # Do processing...
 

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/mlmodelprovider.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/mlmodelprovider.rst
@@ -132,7 +132,6 @@ User is meant to implement the funcionality of the node within the ``test:callba
         for input_batch in ml_model_baseline.input_batch():
             print(input_batch)
         target_latency = ml_model_baseline.target_latency()
-        task_id = ml_model_baseline.task_id()
 
         # HWResource
         # Only in case of optimization (task_id.iteration_id() > 1)
@@ -141,7 +140,12 @@ User is meant to implement the funcionality of the node within the ``test:callba
         latency = hw_baseline.latency()
         memory_footprint_of_ml_model = hw_baseline.memory_footprint_of_ml_model()
         max_hw_memory_footprint = hw_baseline.max_hw_memory_footprint()
-        task_id = hw_baseline.task_id()
+
+        # CarbonFootprint
+        # Only in case of optimization (task_id.iteration_id() > 1)
+        carbon_footprint = carbonfootprint_baseline.carbon_footprint()
+        energy_consumption = carbonfootprint_baseline.energy_consumption()
+        carbon_intesity = carbonfootprint_baseline.carbon_intesity()
 
         # Do processing...
 


### PR DESCRIPTION
This PR fixes some typos in the nodes example snippets