### PR TITLE
Fix Apps requirements list generation in documentation

### DIFF
--- a/sustainml_docs/rst/developer_manual/data_model/data_model.rst
+++ b/sustainml_docs/rst/developer_manual/data_model/data_model.rst
@@ -169,6 +169,7 @@ Application Requirements Type
 -----------------------------
 
 The ``AppRequirements`` data structure depicts the output from the ``Application Requirements Node`` and consists on:
+
 * ``app_requirements``: A sequence of application-level requirements, modeled as a sequence of strings, to be considered in the selection of the machine learning model.
 * ``extra_data``: A sequence of raw extra data for out-of-scope use cases.
 * ``task_id``: The identifier of the ML problem to solve.


### PR DESCRIPTION
SustainML documentation section [App requirements data model](https://sustainml.readthedocs.io/en/latest/rst/developer_manual/data_model/data_model.html#application-requirements-type) contains a list of elements malformed.

This PR includes a line break that fixes documentation generation