### PR TITLE
[21105] Hotfix: Reset cache data before releasing

### DIFF
--- a/sustainml_cpp/include/sustainml_cpp/nodes/AppRequirementsNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/AppRequirementsNode.hpp
@@ -118,7 +118,7 @@ private:
 
     std::mutex mtx_;
 
-    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::AppRequirements>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<types::NodeTaskOutputData<types::AppRequirements>>> task_data_pool_;
 
 };
 

--- a/sustainml_cpp/include/sustainml_cpp/nodes/CarbonFootprintNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/CarbonFootprintNode.hpp
@@ -126,7 +126,7 @@ private:
 
     std::mutex mtx_;
 
-    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::CO2Footprint>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<types::NodeTaskOutputData<types::CO2Footprint>>> task_data_pool_;
 };
 
 } // namespace carbon_tracker_module

--- a/sustainml_cpp/include/sustainml_cpp/nodes/HardwareConstraintsNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/HardwareConstraintsNode.hpp
@@ -118,7 +118,7 @@ private:
 
     std::mutex mtx_;
 
-    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::HWConstraints>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<types::NodeTaskOutputData<types::HWConstraints>>> task_data_pool_;
 
 };
 

--- a/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
@@ -125,7 +125,7 @@ private:
 
     std::mutex mtx_;
 
-    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::HWResource>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<types::NodeTaskOutputData<types::HWResource>>> task_data_pool_;
 
 };
 

--- a/sustainml_cpp/include/sustainml_cpp/nodes/MLModelMetadataNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/MLModelMetadataNode.hpp
@@ -118,7 +118,7 @@ private:
 
     std::mutex mtx_;
 
-    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::MLModelMetadata>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<types::NodeTaskOutputData<types::MLModelMetadata>>> task_data_pool_;
 
 };
 

--- a/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
@@ -135,7 +135,7 @@ private:
 
     std::mutex mtx_;
 
-    std::unique_ptr<utils::SamplePool<std::pair<types::NodeStatus, types::MLModel>>> task_data_pool_;
+    std::unique_ptr<utils::SamplePool<types::NodeTaskOutputData<types::MLModel>>> task_data_pool_;
 
 };
 

--- a/sustainml_cpp/include/sustainml_cpp/types/types.h
+++ b/sustainml_cpp/include/sustainml_cpp/types/types.h
@@ -382,6 +382,11 @@ public:
     AppRequirementsImpl* get_impl();
 
     /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
+
+    /*!
      * @brief This function retrives the implementation type info
      * @return Reference to the typeid
      */
@@ -573,6 +578,11 @@ public:
     CO2FootprintImpl* get_impl();
 
     /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
+
+    /*!
      * @brief This function retrives the implementation type info
      * @return Reference to the typeid
      */
@@ -723,6 +733,11 @@ public:
      * @return Pointer to implementation
      */
     HWConstraintsImpl* get_impl();
+
+    /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
 
     /*!
      * @brief This function retrives the implementation type info
@@ -960,6 +975,11 @@ public:
      * @return Pointer to implementation
      */
     HWResourceImpl* get_impl();
+
+    /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
 
     /*!
      * @brief This function retrives the implementation type info
@@ -1272,6 +1292,11 @@ public:
     MLModelImpl* get_impl();
 
     /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
+
+    /*!
      * @brief This function retrives the implementation type info
      * @return Reference to the typeid
      */
@@ -1455,6 +1480,11 @@ public:
      * @return Pointer to implementation
      */
     MLModelMetadataImpl* get_impl();
+
+    /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
 
     /*!
      * @brief This function retrives the implementation type info
@@ -1651,6 +1681,11 @@ public:
      * @return Pointer to implementation
      */
     NodeControlImpl* get_impl() const;
+
+    /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
 
 protected:
 
@@ -1868,6 +1903,11 @@ public:
      * @return Pointer to implementation
      */
     NodeStatusImpl* get_impl();
+
+    /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
 
 protected:
 
@@ -2303,6 +2343,11 @@ public:
     UserInputImpl* get_impl();
 
     /*!
+     * @brief Resets the structure to default values
+     */
+     void reset();
+
+    /*!
      * @brief This function retrives the implementation type info
      * @return Reference to the typeid
      */
@@ -2315,6 +2360,18 @@ protected:
 
 };
 
+template<typename T>
+struct NodeTaskOutputData
+{
+    types::NodeStatus node_status;
+    T output_data;
+
+    inline void reset()
+    {
+        node_status.reset();
+        output_data.reset();
+    }
+};
 
 } // namespace types
 

--- a/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/CarbonFootprintNode.cpp
@@ -71,7 +71,7 @@ void CarbonFootprintNode::init (
     listener_hw_queue_.reset(new core::QueuedNodeListener<HWResource>(this));
     listener_user_input_queue_.reset(new core::QueuedNodeListener<UserInput>(this));
 
-    task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, CO2Footprint>>(opts));
+    task_data_pool_.reset(new utils::SamplePool<types::NodeTaskOutputData<CO2Footprint>>(opts));
 
     initialize_subscription(sustainml::common::TopicCollection::get()[common::ML_MODEL].first.c_str(),
             sustainml::common::TopicCollection::get()[common::ML_MODEL].second.c_str(),
@@ -106,7 +106,7 @@ void CarbonFootprintNode::publish_to_user(
             ExpectedInputSamples::MAX,
             samples_retrieved);
 
-        std::pair<NodeStatus, CO2Footprint>* task_data_cache;
+        types::NodeTaskOutputData<CO2Footprint>* task_data_cache;
 
         {
             std::lock_guard<std::mutex> lock (mtx_);
@@ -116,8 +116,8 @@ void CarbonFootprintNode::publish_to_user(
 
             task_data_cache = task_data_pool_->get_new_cache_nts();
 
-            status = &task_data_cache->first;
-            output = &task_data_cache->second;
+            status = &task_data_cache->node_status;
+            output = &task_data_cache->output_data;
         }
 
         //! TODO: Manage task statuses individually
@@ -131,9 +131,9 @@ void CarbonFootprintNode::publish_to_user(
         user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<CarbonFootprintCallable::size>{});
 
         //! Ensure task_id is forwarded to the output
-        task_data_cache->second.task_id(task_id);
+        task_data_cache->output_data.task_id(task_id);
 
-        if (task_data_cache->first.node_status() != NODE_ERROR)
+        if (task_data_cache->node_status.node_status() != NODE_ERROR)
         {
             status(NODE_IDLE);
         }
@@ -143,7 +143,7 @@ void CarbonFootprintNode::publish_to_user(
         }
 
         publish_node_status();
-        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
+        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->output_data.get_impl());
 
         listener_ml_model_queue_->remove_element_by_taskid(task_id);
         listener_hw_queue_->remove_element_by_taskid(task_id);

--- a/sustainml_cpp/src/cpp/nodes/MLModelMetadataNode.cpp
+++ b/sustainml_cpp/src/cpp/nodes/MLModelMetadataNode.cpp
@@ -68,7 +68,7 @@ void MLModelMetadataNode::init (
 {
     listener_user_input_queue_.reset(new core::QueuedNodeListener<UserInput>(this));
 
-    task_data_pool_.reset(new utils::SamplePool<std::pair<NodeStatus, MLModelMetadata>>(opts));
+    task_data_pool_.reset(new utils::SamplePool<types::NodeTaskOutputData<MLModelMetadata>>(opts));
 
     initialize_subscription(sustainml::common::TopicCollection::get()[common::USER_INPUT].first.c_str(),
             sustainml::common::TopicCollection::get()[common::USER_INPUT].second.c_str(),
@@ -95,7 +95,7 @@ void MLModelMetadataNode::publish_to_user(
             ExpectedInputSamples::MAX,
             samples_retrieved);
 
-        std::pair<NodeStatus, MLModelMetadata>* task_data_cache;
+        types::NodeTaskOutputData<MLModelMetadata>* task_data_cache;
 
         {
             std::lock_guard<std::mutex> lock (mtx_);
@@ -105,8 +105,8 @@ void MLModelMetadataNode::publish_to_user(
 
             task_data_cache = task_data_pool_->get_new_cache_nts();
 
-            status = &task_data_cache->first;
-            output = &task_data_cache->second;
+            status = &task_data_cache->node_status;
+            output = &task_data_cache->output_data;
         }
 
         //! TODO: Manage task statuses individually
@@ -120,9 +120,9 @@ void MLModelMetadataNode::publish_to_user(
         user_listener_.invoke_user_cb(task_id, core::helper::gen_seq<MLModelMetadataCallable::size>{});
 
         //! Ensure task_id is forwarded to the output
-        task_data_cache->second.task_id(task_id);
+        task_data_cache->output_data.task_id(task_id);
 
-        if (task_data_cache->first.node_status() != NODE_ERROR)
+        if (task_data_cache->node_status.node_status() != NODE_ERROR)
         {
             status(NODE_IDLE);
         }
@@ -132,7 +132,7 @@ void MLModelMetadataNode::publish_to_user(
         }
 
         publish_node_status();
-        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->second.get_impl());
+        writers()[OUTPUT_WRITER_IDX]->write(task_data_cache->output_data.get_impl());
 
         listener_user_input_queue_->remove_element_by_taskid(task_id);
 

--- a/sustainml_cpp/src/cpp/types/types.cpp
+++ b/sustainml_cpp/src/cpp/types/types.cpp
@@ -327,6 +327,17 @@ NodeStatusImpl* NodeStatus::get_impl()
     return impl_;
 }
 
+void NodeStatus::reset()
+{
+    impl_->node_status(Status::NODE_IDLE);
+    impl_->node_name("");
+    impl_->task_status(TaskStatus::TASK_SUCCEEDED);
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
+    impl_->error_code(ErrorCode::NO_ERROR);
+    impl_->error_description("");
+}
+
 NodeControl::NodeControl()
 {
     impl_ = new NodeControlImpl;
@@ -496,6 +507,16 @@ std::string& NodeControl::source_node()
 NodeControlImpl* NodeControl::get_impl() const
 {
     return impl_;
+}
+
+void NodeControl::reset()
+{
+    impl_->cmd_node(CmdNode::NO_CMD_NODE);
+    impl_->source_node("");
+    impl_->target_node("");
+    impl_->cmd_task(CmdTask::NO_CMD_TASK);
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
 }
 
 UserInput::UserInput()
@@ -886,6 +907,26 @@ UserInputImpl* UserInput::get_impl()
     return impl_;
 }
 
+void UserInput::reset()
+{
+    impl_->modality("");
+    impl_->problem_short_description("");
+    impl_->problem_definition("");
+    impl_->inputs().clear();
+    impl_->outputs().clear();
+    impl_->minimum_samples(0);
+    impl_->maximum_samples(0);
+    impl_->optimize_carbon_footprint_manual(false);
+    impl_->previous_iteration(0);
+    impl_->optimize_carbon_footprint_auto(false);
+    impl_->desired_carbon_footprint(0.0);
+    impl_->geo_location_continent("");
+    impl_->geo_location_region("");
+    impl_->extra_data().clear();
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
+}
+
 const std::type_info& UserInput::impl_typeinfo()
 {
     return typeid(UserInputImpl);
@@ -1051,6 +1092,15 @@ MLModelMetadataImpl* MLModelMetadata::get_impl()
     return impl_;
 }
 
+void MLModelMetadata::reset()
+{
+    impl_->keywords().clear();
+    impl_->ml_model_metadata().clear();
+    impl_->extra_data().clear();
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
+}
+
 const std::type_info& MLModelMetadata::impl_typeinfo()
 {
     return typeid(MLModelMetadataImpl);
@@ -1191,6 +1241,14 @@ AppRequirementsImpl* AppRequirements::get_impl()
     return impl_;
 }
 
+void AppRequirements::reset()
+{
+    impl_->app_requirements().clear();
+    impl_->extra_data().clear();
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
+}
+
 const std::type_info& AppRequirements::impl_typeinfo()
 {
     return typeid(AppRequirementsImpl);
@@ -1323,6 +1381,14 @@ TaskId& HWConstraints::task_id()
 HWConstraintsImpl* HWConstraints::get_impl()
 {
     return impl_;
+}
+
+void HWConstraints::reset()
+{
+    impl_->max_memory_footprint(0);
+    impl_->extra_data().clear();
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
 }
 
 const std::type_info& HWConstraints::impl_typeinfo()
@@ -1603,6 +1669,20 @@ MLModelImpl* MLModel::get_impl()
     return impl_;
 }
 
+void MLModel::reset()
+{
+    impl_->model("");
+    impl_->model_path("");
+    impl_->raw_model().clear();
+    impl_->model_properties_path("");
+    impl_->model_properties("");
+    impl_->input_batch().clear();
+    impl_->target_latency(0.0);
+    impl_->extra_data().clear();
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
+}
+
 const std::type_info& MLModel::impl_typeinfo()
 {
     return typeid(MLModelImpl);
@@ -1815,6 +1895,18 @@ HWResourceImpl* HWResource::get_impl()
     return impl_;
 }
 
+void HWResource::reset()
+{
+    impl_->hw_description("");
+    impl_->power_consumption(0.0);
+    impl_->latency(0.0);
+    impl_->memory_footprint_of_ml_model(0.0);
+    impl_->max_hw_memory_footprint(0.0);
+    impl_->extra_data().clear();
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
+}
+
 const std::type_info& HWResource::impl_typeinfo()
 {
     return typeid(HWResourceImpl);
@@ -1985,6 +2077,16 @@ TaskId& CO2Footprint::task_id()
 CO2FootprintImpl* CO2Footprint::get_impl()
 {
     return impl_;
+}
+
+void CO2Footprint::reset()
+{
+    impl_->carbon_intensity(0.0);
+    impl_->carbon_footprint(0.0);
+    impl_->energy_consumption(0.0);
+    impl_->extra_data().clear();
+    impl_->task_id().problem_id(sustainml::common::INVALID_ID);
+    impl_->task_id().iteration_id(sustainml::common::INVALID_ID);
 }
 
 const std::type_info& CO2Footprint::impl_typeinfo()

--- a/sustainml_cpp/src/cpp/utils/SamplePool.hpp
+++ b/sustainml_cpp/src/cpp/utils/SamplePool.hpp
@@ -71,9 +71,9 @@ namespace utils {
 
         void release_cache_nts(T* cache)
         {
-
             if (nullptr != cache)
             {
+                cache->reset();
                 free_caches_.push_back(cache);
             }
             else


### PR DESCRIPTION
`SamplePool` was not resetting the cache before releasing it. Thsi causes a bad bahavior when the caches are successively reused, specially in the case of vectors, that tend to accumulate elements across different tasks, specially, the `task_data_pool_` in each of the nodes was the most affected. This PR includes a `type_trait` of having a `reset()` method so that data can be reset to default before being given back to the free caches vector.