### PR TITLE
[21520] Update CI with required packages from submodules

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -67,6 +67,12 @@ jobs:
           requirements_file_name: ${{ github.workspace }}/src/sustainml_lib/sustainml_docs/requirements.txt
           upgrade: false
 
+      - name: Install Python submodules dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          requirements_file_name: ${{ github.workspace }}/src/sustainml_lib/sustainml_modules/requirements.txt
+          upgrade: false
+
       - name: Download repos file
         uses: eProsima/eProsima-CI/multiplatform/get_file_from_repo@v0
         with:
@@ -123,6 +129,12 @@ jobs:
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           requirements_file_name: ${{ github.workspace }}/src/sustainml_lib/sustainml_docs/requirements.txt
+          upgrade: false
+
+      - name: Install Python submodules dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          requirements_file_name: ${{ github.workspace }}/src/sustainml_lib/sustainml_modules/requirements.txt
           upgrade: false
 
       - name: Download repos file

--- a/sustainml.repos
+++ b/sustainml.repos
@@ -14,7 +14,7 @@ repositories:
     dev-utils:
         type: git
         url: https://github.com/eProsima/dev-utils.git
-        version: main
+        version: 0.x
     sustainml_lib:
         type: git
         url: https://github.com/eProsima/SustainML-Library.git


### PR DESCRIPTION
This PR updates the ci to install the required python packages required for `wp1`. It also fixes a `dev-utils` dependency to `0.x` 