### PR TITLE
[22026]  Add new field `hardware_required` in Hardware Constraints Data type and IDL

### DIFF
--- a/sustainml_cpp/examples/CliModules/main.cpp
+++ b/sustainml_cpp/examples/CliModules/main.cpp
@@ -405,6 +405,7 @@ class CustomHardwareConstraintsListener : public sustainml::hardware_module::Har
 
         // Populate output
         output.max_memory_footprint(user_input.task_id().problem_id());
+        output.hardware_required(std::vector<std::string>{"PIM_AI_1chip"});
 
         // Wait the time it takes the node to generate the output
         sleep(1);

--- a/sustainml_cpp/examples/CliModules/typesImpl.hpp
+++ b/sustainml_cpp/examples/CliModules/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-               m_iteration_id == x.m_iteration_id);
+           m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,6 +209,7 @@ public:
         return m_problem_id;
     }
 
+
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -236,6 +237,8 @@ public:
     {
         return m_iteration_id;
     }
+
+
 
 private:
 
@@ -272,17 +275,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -309,17 +312,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -349,11 +352,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-               m_task_status == x.m_task_status &&
-               m_error_code == x.m_error_code &&
-               m_error_description == x.m_error_description &&
-               m_node_name == x.m_node_name &&
-               m_task_id == x.m_task_id);
+           m_task_status == x.m_task_status &&
+           m_error_code == x.m_error_code &&
+           m_error_description == x.m_error_description &&
+           m_node_name == x.m_node_name &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -394,6 +397,7 @@ public:
         return m_node_status;
     }
 
+
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -422,6 +426,7 @@ public:
         return m_task_status;
     }
 
+
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -449,6 +454,7 @@ public:
     {
         return m_error_code;
     }
+
 
     /*!
      * @brief This function copies the value in member error_description
@@ -488,6 +494,7 @@ public:
         return m_error_description;
     }
 
+
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -526,6 +533,7 @@ public:
         return m_node_name;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -563,6 +571,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -627,15 +637,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -661,15 +671,15 @@ public:
             const NodeControlImpl& x)
     {
 
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -698,10 +708,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-               m_cmd_task == x.m_cmd_task &&
-               m_target_node == x.m_target_node &&
-               m_source_node == x.m_source_node &&
-               m_task_id == x.m_task_id);
+           m_cmd_task == x.m_cmd_task &&
+           m_target_node == x.m_target_node &&
+           m_source_node == x.m_source_node &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -742,6 +752,7 @@ public:
         return m_cmd_node;
     }
 
+
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -769,6 +780,7 @@ public:
     {
         return m_cmd_task;
     }
+
 
     /*!
      * @brief This function copies the value in member target_node
@@ -808,6 +820,7 @@ public:
         return m_target_node;
     }
 
+
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -845,6 +858,7 @@ public:
     {
         return m_source_node;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -884,6 +898,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -922,35 +938,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -986,35 +1002,35 @@ public:
             const UserInputImpl& x)
     {
 
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1053,20 +1069,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-               m_problem_short_description == x.m_problem_short_description &&
-               m_problem_definition == x.m_problem_definition &&
-               m_inputs == x.m_inputs &&
-               m_outputs == x.m_outputs &&
-               m_minimum_samples == x.m_minimum_samples &&
-               m_maximum_samples == x.m_maximum_samples &&
-               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-               m_previous_iteration == x.m_previous_iteration &&
-               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-               m_geo_location_continent == x.m_geo_location_continent &&
-               m_geo_location_region == x.m_geo_location_region &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_problem_short_description == x.m_problem_short_description &&
+           m_problem_definition == x.m_problem_definition &&
+           m_inputs == x.m_inputs &&
+           m_outputs == x.m_outputs &&
+           m_minimum_samples == x.m_minimum_samples &&
+           m_maximum_samples == x.m_maximum_samples &&
+           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+           m_previous_iteration == x.m_previous_iteration &&
+           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+           m_geo_location_continent == x.m_geo_location_continent &&
+           m_geo_location_region == x.m_geo_location_region &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1117,6 +1133,7 @@ public:
         return m_modality;
     }
 
+
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1154,6 +1171,7 @@ public:
     {
         return m_problem_short_description;
     }
+
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1193,6 +1211,7 @@ public:
         return m_problem_definition;
     }
 
+
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1230,6 +1249,7 @@ public:
     {
         return m_inputs;
     }
+
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1269,6 +1289,7 @@ public:
         return m_outputs;
     }
 
+
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1296,6 +1317,7 @@ public:
     {
         return m_minimum_samples;
     }
+
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1325,6 +1347,7 @@ public:
         return m_maximum_samples;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1352,6 +1375,7 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
+
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1381,6 +1405,7 @@ public:
         return m_previous_iteration;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1409,6 +1434,7 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
+
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1436,6 +1462,7 @@ public:
     {
         return m_desired_carbon_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1475,6 +1502,7 @@ public:
         return m_geo_location_continent;
     }
 
+
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1512,6 +1540,7 @@ public:
     {
         return m_geo_location_region;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1551,6 +1580,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1588,6 +1618,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -1637,13 +1669,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1668,13 +1700,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1702,9 +1734,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-               m_ml_model_metadata == x.m_ml_model_metadata &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_ml_model_metadata == x.m_ml_model_metadata &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1755,6 +1787,7 @@ public:
         return m_keywords;
     }
 
+
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1792,6 +1825,7 @@ public:
     {
         return m_ml_model_metadata;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1831,6 +1865,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1869,6 +1904,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_keywords;
@@ -1906,11 +1943,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1934,11 +1971,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1965,8 +2002,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2017,6 +2054,7 @@ public:
         return m_app_requirements;
     }
 
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2054,6 +2092,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2093,6 +2132,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2129,11 +2170,11 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2157,11 +2198,11 @@ public:
             const HWConstraintsImpl& x)
     {
 
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2188,8 +2229,8 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2230,6 +2271,7 @@ public:
         return m_max_memory_footprint;
     }
 
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2267,6 +2309,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2306,6 +2349,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     uint32_t m_max_memory_footprint{0};
@@ -2342,23 +2387,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2388,23 +2433,23 @@ public:
             const MLModelImpl& x)
     {
 
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2437,14 +2482,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-               m_model == x.m_model &&
-               m_raw_model == x.m_raw_model &&
-               m_model_properties_path == x.m_model_properties_path &&
-               m_model_properties == x.m_model_properties &&
-               m_input_batch == x.m_input_batch &&
-               m_target_latency == x.m_target_latency &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_model == x.m_model &&
+           m_raw_model == x.m_raw_model &&
+           m_model_properties_path == x.m_model_properties_path &&
+           m_model_properties == x.m_model_properties &&
+           m_input_batch == x.m_input_batch &&
+           m_target_latency == x.m_target_latency &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2495,6 +2540,7 @@ public:
         return m_model_path;
     }
 
+
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2532,6 +2578,7 @@ public:
     {
         return m_model;
     }
+
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2571,6 +2618,7 @@ public:
         return m_raw_model;
     }
 
+
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2608,6 +2656,7 @@ public:
     {
         return m_model_properties_path;
     }
+
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2647,6 +2696,7 @@ public:
         return m_model_properties;
     }
 
+
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2685,6 +2735,7 @@ public:
         return m_input_batch;
     }
 
+
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2712,6 +2763,7 @@ public:
     {
         return m_target_latency;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2751,6 +2803,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2788,6 +2841,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -2831,19 +2886,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2871,19 +2926,19 @@ public:
             const HWResourceImpl& x)
     {
 
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2914,12 +2969,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-               m_power_consumption == x.m_power_consumption &&
-               m_latency == x.m_latency &&
-               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_power_consumption == x.m_power_consumption &&
+           m_latency == x.m_latency &&
+           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2970,6 +3025,7 @@ public:
         return m_hw_description;
     }
 
+
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -2997,6 +3053,7 @@ public:
     {
         return m_power_consumption;
     }
+
 
     /*!
      * @brief This function sets a value in member latency
@@ -3026,6 +3083,7 @@ public:
         return m_latency;
     }
 
+
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3054,6 +3112,7 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
+
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3081,6 +3140,7 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3120,6 +3180,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3157,6 +3218,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -3198,15 +3261,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -3232,15 +3295,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3269,10 +3332,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-               m_energy_consumption == x.m_energy_consumption &&
-               m_carbon_intensity == x.m_carbon_intensity &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_energy_consumption == x.m_energy_consumption &&
+           m_carbon_intensity == x.m_carbon_intensity &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3313,6 +3376,7 @@ public:
         return m_carbon_footprint;
     }
 
+
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3341,6 +3405,7 @@ public:
         return m_energy_consumption;
     }
 
+
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3368,6 +3433,7 @@ public:
     {
         return m_carbon_intensity;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3407,6 +3473,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3444,6 +3511,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 

--- a/sustainml_cpp/examples/CliModules/typesImpl.hpp
+++ b/sustainml_cpp/examples/CliModules/typesImpl.hpp
@@ -2172,6 +2172,8 @@ public:
     {
                     m_max_memory_footprint = x.m_max_memory_footprint;
 
+                    m_hardware_required = x.m_hardware_required;
+
                     m_extra_data = x.m_extra_data;
 
                     m_task_id = x.m_task_id;
@@ -2186,6 +2188,7 @@ public:
             HWConstraintsImpl&& x) noexcept
     {
         m_max_memory_footprint = x.m_max_memory_footprint;
+        m_hardware_required = std::move(x.m_hardware_required);
         m_extra_data = std::move(x.m_extra_data);
         m_task_id = std::move(x.m_task_id);
     }
@@ -2199,6 +2202,8 @@ public:
     {
 
                     m_max_memory_footprint = x.m_max_memory_footprint;
+
+                    m_hardware_required = x.m_hardware_required;
 
                     m_extra_data = x.m_extra_data;
 
@@ -2216,6 +2221,7 @@ public:
     {
 
         m_max_memory_footprint = x.m_max_memory_footprint;
+        m_hardware_required = std::move(x.m_hardware_required);
         m_extra_data = std::move(x.m_extra_data);
         m_task_id = std::move(x.m_task_id);
         return *this;
@@ -2229,6 +2235,7 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
+           m_hardware_required == x.m_hardware_required &&
            m_extra_data == x.m_extra_data &&
            m_task_id == x.m_task_id);
     }
@@ -2269,6 +2276,45 @@ public:
     eProsima_user_DllExport uint32_t& max_memory_footprint()
     {
         return m_max_memory_footprint;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member hardware_required
+     * @param _hardware_required New value to be copied in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            const std::vector<std::string>& _hardware_required)
+    {
+        m_hardware_required = _hardware_required;
+    }
+
+    /*!
+     * @brief This function moves the value in member hardware_required
+     * @param _hardware_required New value to be moved in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            std::vector<std::string>&& _hardware_required)
+    {
+        m_hardware_required = std::move(_hardware_required);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member hardware_required
+     * @return Constant reference to member hardware_required
+     */
+    eProsima_user_DllExport const std::vector<std::string>& hardware_required() const
+    {
+        return m_hardware_required;
+    }
+
+    /*!
+     * @brief This function returns a reference to member hardware_required
+     * @return Reference to member hardware_required
+     */
+    eProsima_user_DllExport std::vector<std::string>& hardware_required()
+    {
+        return m_hardware_required;
     }
 
 
@@ -2354,6 +2400,7 @@ public:
 private:
 
     uint32_t m_max_memory_footprint{0};
+    std::vector<std::string> m_hardware_required;
     std::vector<uint8_t> m_extra_data;
     TaskIdImpl m_task_id;
 

--- a/sustainml_cpp/examples/CliModules/typesImpl.hpp
+++ b/sustainml_cpp/examples/CliModules/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-                    m_problem_id = x.m_problem_id;
+        m_problem_id = x.m_problem_id;
 
-                    m_iteration_id = x.m_iteration_id;
+        m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-                    m_problem_id = x.m_problem_id;
+        m_problem_id = x.m_problem_id;
 
-                    m_iteration_id = x.m_iteration_id;
+        m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-           m_iteration_id == x.m_iteration_id);
+               m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,7 +209,6 @@ public:
         return m_problem_id;
     }
 
-
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -237,8 +236,6 @@ public:
     {
         return m_iteration_id;
     }
-
-
 
 private:
 
@@ -275,17 +272,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-                    m_node_status = x.m_node_status;
+        m_node_status = x.m_node_status;
 
-                    m_task_status = x.m_task_status;
+        m_task_status = x.m_task_status;
 
-                    m_error_code = x.m_error_code;
+        m_error_code = x.m_error_code;
 
-                    m_error_description = x.m_error_description;
+        m_error_description = x.m_error_description;
 
-                    m_node_name = x.m_node_name;
+        m_node_name = x.m_node_name;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -312,17 +309,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-                    m_node_status = x.m_node_status;
+        m_node_status = x.m_node_status;
 
-                    m_task_status = x.m_task_status;
+        m_task_status = x.m_task_status;
 
-                    m_error_code = x.m_error_code;
+        m_error_code = x.m_error_code;
 
-                    m_error_description = x.m_error_description;
+        m_error_description = x.m_error_description;
 
-                    m_node_name = x.m_node_name;
+        m_node_name = x.m_node_name;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -352,11 +349,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-           m_task_status == x.m_task_status &&
-           m_error_code == x.m_error_code &&
-           m_error_description == x.m_error_description &&
-           m_node_name == x.m_node_name &&
-           m_task_id == x.m_task_id);
+               m_task_status == x.m_task_status &&
+               m_error_code == x.m_error_code &&
+               m_error_description == x.m_error_description &&
+               m_node_name == x.m_node_name &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -397,7 +394,6 @@ public:
         return m_node_status;
     }
 
-
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -426,7 +422,6 @@ public:
         return m_task_status;
     }
 
-
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -454,7 +449,6 @@ public:
     {
         return m_error_code;
     }
-
 
     /*!
      * @brief This function copies the value in member error_description
@@ -494,7 +488,6 @@ public:
         return m_error_description;
     }
 
-
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -533,7 +526,6 @@ public:
         return m_node_name;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -571,8 +563,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -637,15 +627,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-                    m_cmd_node = x.m_cmd_node;
+        m_cmd_node = x.m_cmd_node;
 
-                    m_cmd_task = x.m_cmd_task;
+        m_cmd_task = x.m_cmd_task;
 
-                    m_target_node = x.m_target_node;
+        m_target_node = x.m_target_node;
 
-                    m_source_node = x.m_source_node;
+        m_source_node = x.m_source_node;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -671,15 +661,15 @@ public:
             const NodeControlImpl& x)
     {
 
-                    m_cmd_node = x.m_cmd_node;
+        m_cmd_node = x.m_cmd_node;
 
-                    m_cmd_task = x.m_cmd_task;
+        m_cmd_task = x.m_cmd_task;
 
-                    m_target_node = x.m_target_node;
+        m_target_node = x.m_target_node;
 
-                    m_source_node = x.m_source_node;
+        m_source_node = x.m_source_node;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -708,10 +698,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-           m_cmd_task == x.m_cmd_task &&
-           m_target_node == x.m_target_node &&
-           m_source_node == x.m_source_node &&
-           m_task_id == x.m_task_id);
+               m_cmd_task == x.m_cmd_task &&
+               m_target_node == x.m_target_node &&
+               m_source_node == x.m_source_node &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -752,7 +742,6 @@ public:
         return m_cmd_node;
     }
 
-
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -780,7 +769,6 @@ public:
     {
         return m_cmd_task;
     }
-
 
     /*!
      * @brief This function copies the value in member target_node
@@ -820,7 +808,6 @@ public:
         return m_target_node;
     }
 
-
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -858,7 +845,6 @@ public:
     {
         return m_source_node;
     }
-
 
     /*!
      * @brief This function copies the value in member task_id
@@ -898,8 +884,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -938,35 +922,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-                    m_modality = x.m_modality;
+        m_modality = x.m_modality;
 
-                    m_problem_short_description = x.m_problem_short_description;
+        m_problem_short_description = x.m_problem_short_description;
 
-                    m_problem_definition = x.m_problem_definition;
+        m_problem_definition = x.m_problem_definition;
 
-                    m_inputs = x.m_inputs;
+        m_inputs = x.m_inputs;
 
-                    m_outputs = x.m_outputs;
+        m_outputs = x.m_outputs;
 
-                    m_minimum_samples = x.m_minimum_samples;
+        m_minimum_samples = x.m_minimum_samples;
 
-                    m_maximum_samples = x.m_maximum_samples;
+        m_maximum_samples = x.m_maximum_samples;
 
-                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-                    m_previous_iteration = x.m_previous_iteration;
+        m_previous_iteration = x.m_previous_iteration;
 
-                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-                    m_geo_location_continent = x.m_geo_location_continent;
+        m_geo_location_continent = x.m_geo_location_continent;
 
-                    m_geo_location_region = x.m_geo_location_region;
+        m_geo_location_region = x.m_geo_location_region;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1002,35 +986,35 @@ public:
             const UserInputImpl& x)
     {
 
-                    m_modality = x.m_modality;
+        m_modality = x.m_modality;
 
-                    m_problem_short_description = x.m_problem_short_description;
+        m_problem_short_description = x.m_problem_short_description;
 
-                    m_problem_definition = x.m_problem_definition;
+        m_problem_definition = x.m_problem_definition;
 
-                    m_inputs = x.m_inputs;
+        m_inputs = x.m_inputs;
 
-                    m_outputs = x.m_outputs;
+        m_outputs = x.m_outputs;
 
-                    m_minimum_samples = x.m_minimum_samples;
+        m_minimum_samples = x.m_minimum_samples;
 
-                    m_maximum_samples = x.m_maximum_samples;
+        m_maximum_samples = x.m_maximum_samples;
 
-                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-                    m_previous_iteration = x.m_previous_iteration;
+        m_previous_iteration = x.m_previous_iteration;
 
-                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-                    m_geo_location_continent = x.m_geo_location_continent;
+        m_geo_location_continent = x.m_geo_location_continent;
 
-                    m_geo_location_region = x.m_geo_location_region;
+        m_geo_location_region = x.m_geo_location_region;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1069,20 +1053,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-           m_problem_short_description == x.m_problem_short_description &&
-           m_problem_definition == x.m_problem_definition &&
-           m_inputs == x.m_inputs &&
-           m_outputs == x.m_outputs &&
-           m_minimum_samples == x.m_minimum_samples &&
-           m_maximum_samples == x.m_maximum_samples &&
-           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-           m_previous_iteration == x.m_previous_iteration &&
-           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-           m_geo_location_continent == x.m_geo_location_continent &&
-           m_geo_location_region == x.m_geo_location_region &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_problem_short_description == x.m_problem_short_description &&
+               m_problem_definition == x.m_problem_definition &&
+               m_inputs == x.m_inputs &&
+               m_outputs == x.m_outputs &&
+               m_minimum_samples == x.m_minimum_samples &&
+               m_maximum_samples == x.m_maximum_samples &&
+               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+               m_previous_iteration == x.m_previous_iteration &&
+               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+               m_geo_location_continent == x.m_geo_location_continent &&
+               m_geo_location_region == x.m_geo_location_region &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1133,7 +1117,6 @@ public:
         return m_modality;
     }
 
-
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1171,7 +1154,6 @@ public:
     {
         return m_problem_short_description;
     }
-
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1211,7 +1193,6 @@ public:
         return m_problem_definition;
     }
 
-
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1249,7 +1230,6 @@ public:
     {
         return m_inputs;
     }
-
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1289,7 +1269,6 @@ public:
         return m_outputs;
     }
 
-
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1317,7 +1296,6 @@ public:
     {
         return m_minimum_samples;
     }
-
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1347,7 +1325,6 @@ public:
         return m_maximum_samples;
     }
 
-
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1375,7 +1352,6 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
-
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1405,7 +1381,6 @@ public:
         return m_previous_iteration;
     }
 
-
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1434,7 +1409,6 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
-
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1462,7 +1436,6 @@ public:
     {
         return m_desired_carbon_footprint;
     }
-
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1502,7 +1475,6 @@ public:
         return m_geo_location_continent;
     }
 
-
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1540,7 +1512,6 @@ public:
     {
         return m_geo_location_region;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1580,7 +1551,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1618,8 +1588,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -1669,13 +1637,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-                    m_keywords = x.m_keywords;
+        m_keywords = x.m_keywords;
 
-                    m_ml_model_metadata = x.m_ml_model_metadata;
+        m_ml_model_metadata = x.m_ml_model_metadata;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1700,13 +1668,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-                    m_keywords = x.m_keywords;
+        m_keywords = x.m_keywords;
 
-                    m_ml_model_metadata = x.m_ml_model_metadata;
+        m_ml_model_metadata = x.m_ml_model_metadata;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1734,9 +1702,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-           m_ml_model_metadata == x.m_ml_model_metadata &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_ml_model_metadata == x.m_ml_model_metadata &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1787,7 +1755,6 @@ public:
         return m_keywords;
     }
 
-
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1825,7 +1792,6 @@ public:
     {
         return m_ml_model_metadata;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1865,7 +1831,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1904,8 +1869,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     std::vector<std::string> m_keywords;
@@ -1943,11 +1906,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-                    m_app_requirements = x.m_app_requirements;
+        m_app_requirements = x.m_app_requirements;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1971,11 +1934,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-                    m_app_requirements = x.m_app_requirements;
+        m_app_requirements = x.m_app_requirements;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2002,8 +1965,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2054,7 +2017,6 @@ public:
         return m_app_requirements;
     }
 
-
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2092,7 +2054,6 @@ public:
     {
         return m_extra_data;
     }
-
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2132,8 +2093,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2170,13 +2129,13 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-                    m_max_memory_footprint = x.m_max_memory_footprint;
+        m_max_memory_footprint = x.m_max_memory_footprint;
 
-                    m_hardware_required = x.m_hardware_required;
+        m_hardware_required = x.m_hardware_required;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2201,13 +2160,13 @@ public:
             const HWConstraintsImpl& x)
     {
 
-                    m_max_memory_footprint = x.m_max_memory_footprint;
+        m_max_memory_footprint = x.m_max_memory_footprint;
 
-                    m_hardware_required = x.m_hardware_required;
+        m_hardware_required = x.m_hardware_required;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2235,9 +2194,9 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-           m_hardware_required == x.m_hardware_required &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_hardware_required == x.m_hardware_required &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2278,7 +2237,6 @@ public:
         return m_max_memory_footprint;
     }
 
-
     /*!
      * @brief This function copies the value in member hardware_required
      * @param _hardware_required New value to be copied in member hardware_required
@@ -2316,7 +2274,6 @@ public:
     {
         return m_hardware_required;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2356,7 +2313,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2395,8 +2351,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     uint32_t m_max_memory_footprint{0};
@@ -2434,23 +2388,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-                    m_model_path = x.m_model_path;
+        m_model_path = x.m_model_path;
 
-                    m_model = x.m_model;
+        m_model = x.m_model;
 
-                    m_raw_model = x.m_raw_model;
+        m_raw_model = x.m_raw_model;
 
-                    m_model_properties_path = x.m_model_properties_path;
+        m_model_properties_path = x.m_model_properties_path;
 
-                    m_model_properties = x.m_model_properties;
+        m_model_properties = x.m_model_properties;
 
-                    m_input_batch = x.m_input_batch;
+        m_input_batch = x.m_input_batch;
 
-                    m_target_latency = x.m_target_latency;
+        m_target_latency = x.m_target_latency;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2480,23 +2434,23 @@ public:
             const MLModelImpl& x)
     {
 
-                    m_model_path = x.m_model_path;
+        m_model_path = x.m_model_path;
 
-                    m_model = x.m_model;
+        m_model = x.m_model;
 
-                    m_raw_model = x.m_raw_model;
+        m_raw_model = x.m_raw_model;
 
-                    m_model_properties_path = x.m_model_properties_path;
+        m_model_properties_path = x.m_model_properties_path;
 
-                    m_model_properties = x.m_model_properties;
+        m_model_properties = x.m_model_properties;
 
-                    m_input_batch = x.m_input_batch;
+        m_input_batch = x.m_input_batch;
 
-                    m_target_latency = x.m_target_latency;
+        m_target_latency = x.m_target_latency;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2529,14 +2483,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-           m_model == x.m_model &&
-           m_raw_model == x.m_raw_model &&
-           m_model_properties_path == x.m_model_properties_path &&
-           m_model_properties == x.m_model_properties &&
-           m_input_batch == x.m_input_batch &&
-           m_target_latency == x.m_target_latency &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_model == x.m_model &&
+               m_raw_model == x.m_raw_model &&
+               m_model_properties_path == x.m_model_properties_path &&
+               m_model_properties == x.m_model_properties &&
+               m_input_batch == x.m_input_batch &&
+               m_target_latency == x.m_target_latency &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2587,7 +2541,6 @@ public:
         return m_model_path;
     }
 
-
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2625,7 +2578,6 @@ public:
     {
         return m_model;
     }
-
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2665,7 +2617,6 @@ public:
         return m_raw_model;
     }
 
-
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2703,7 +2654,6 @@ public:
     {
         return m_model_properties_path;
     }
-
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2743,7 +2693,6 @@ public:
         return m_model_properties;
     }
 
-
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2782,7 +2731,6 @@ public:
         return m_input_batch;
     }
 
-
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2810,7 +2758,6 @@ public:
     {
         return m_target_latency;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2850,7 +2797,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2888,8 +2834,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -2933,19 +2877,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-                    m_hw_description = x.m_hw_description;
+        m_hw_description = x.m_hw_description;
 
-                    m_power_consumption = x.m_power_consumption;
+        m_power_consumption = x.m_power_consumption;
 
-                    m_latency = x.m_latency;
+        m_latency = x.m_latency;
 
-                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2973,19 +2917,19 @@ public:
             const HWResourceImpl& x)
     {
 
-                    m_hw_description = x.m_hw_description;
+        m_hw_description = x.m_hw_description;
 
-                    m_power_consumption = x.m_power_consumption;
+        m_power_consumption = x.m_power_consumption;
 
-                    m_latency = x.m_latency;
+        m_latency = x.m_latency;
 
-                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3016,12 +2960,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-           m_power_consumption == x.m_power_consumption &&
-           m_latency == x.m_latency &&
-           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_power_consumption == x.m_power_consumption &&
+               m_latency == x.m_latency &&
+               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3072,7 +3016,6 @@ public:
         return m_hw_description;
     }
 
-
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -3100,7 +3043,6 @@ public:
     {
         return m_power_consumption;
     }
-
 
     /*!
      * @brief This function sets a value in member latency
@@ -3130,7 +3072,6 @@ public:
         return m_latency;
     }
 
-
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3159,7 +3100,6 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
-
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3187,7 +3127,6 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3227,7 +3166,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3265,8 +3203,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -3308,15 +3244,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-                    m_carbon_footprint = x.m_carbon_footprint;
+        m_carbon_footprint = x.m_carbon_footprint;
 
-                    m_energy_consumption = x.m_energy_consumption;
+        m_energy_consumption = x.m_energy_consumption;
 
-                    m_carbon_intensity = x.m_carbon_intensity;
+        m_carbon_intensity = x.m_carbon_intensity;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -3342,15 +3278,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-                    m_carbon_footprint = x.m_carbon_footprint;
+        m_carbon_footprint = x.m_carbon_footprint;
 
-                    m_energy_consumption = x.m_energy_consumption;
+        m_energy_consumption = x.m_energy_consumption;
 
-                    m_carbon_intensity = x.m_carbon_intensity;
+        m_carbon_intensity = x.m_carbon_intensity;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3379,10 +3315,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-           m_energy_consumption == x.m_energy_consumption &&
-           m_carbon_intensity == x.m_carbon_intensity &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_energy_consumption == x.m_energy_consumption &&
+               m_carbon_intensity == x.m_carbon_intensity &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3423,7 +3359,6 @@ public:
         return m_carbon_footprint;
     }
 
-
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3452,7 +3387,6 @@ public:
         return m_energy_consumption;
     }
 
-
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3480,7 +3414,6 @@ public:
     {
         return m_carbon_intensity;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3520,7 +3453,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3558,8 +3490,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 

--- a/sustainml_cpp/examples/CliModules/typesImpl.idl
+++ b/sustainml_cpp/examples/CliModules/typesImpl.idl
@@ -98,6 +98,7 @@ struct AppRequirementsImpl
 struct HWConstraintsImpl
 {
     unsigned long max_memory_footprint;
+    sequence<string> hardware_required;
     sequence<octet> extra_data;
     @key TaskIdImpl task_id;
  };

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.hpp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.hpp
@@ -36,7 +36,7 @@ constexpr uint32_t MLModelImpl_max_key_cdr_typesize {12UL};
 constexpr uint32_t MLModelMetadataImpl_max_cdr_typesize {36UL};
 constexpr uint32_t MLModelMetadataImpl_max_key_cdr_typesize {12UL};
 
-constexpr uint32_t HWConstraintsImpl_max_cdr_typesize {24UL};
+constexpr uint32_t HWConstraintsImpl_max_cdr_typesize {32UL};
 constexpr uint32_t HWConstraintsImpl_max_key_cdr_typesize {12UL};
 
 constexpr uint32_t CO2FootprintImpl_max_cdr_typesize {48UL};

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
@@ -32,77 +32,74 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-    namespace fastcdr {
+namespace fastcdr {
 
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const TaskIdImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const TaskIdImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.problem_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.problem_id(), current_alignment);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.iteration_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.iteration_id(), current_alignment);
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-            return calculated_size;
-        }
+    return calculated_size;
+}
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.problem_id()
-                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.problem_id()
+        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+;
+    scdr.end_serialize_type(current_state);
+}
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                TaskIdImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        TaskIdImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.problem_id();
-                        break;
+                                        case 0:
+                                                dcdr >> data.problem_id();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.iteration_id();
-                        break;
+                                        case 1:
+                                                dcdr >> data.iteration_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -110,122 +107,120 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.problem_id();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.problem_id();
 
-            scdr << data.iteration_id();
+                        scdr << data.iteration_id();
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeStatusImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.node_status(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeStatusImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.task_status(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.error_code(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.error_description(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.node_name(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_status(), current_alignment);
 
-            return calculated_size;
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.task_status(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.error_code(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.node_status()
-                << eprosima::fastcdr::MemberId(1) << data.task_status()
-                << eprosima::fastcdr::MemberId(2) << data.error_code()
-                << eprosima::fastcdr::MemberId(3) << data.error_description()
-                << eprosima::fastcdr::MemberId(4) << data.node_name()
-                << eprosima::fastcdr::MemberId(5) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.error_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeStatusImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.node_name(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.node_status()
+        << eprosima::fastcdr::MemberId(1) << data.task_status()
+        << eprosima::fastcdr::MemberId(2) << data.error_code()
+        << eprosima::fastcdr::MemberId(3) << data.error_description()
+        << eprosima::fastcdr::MemberId(4) << data.node_name()
+        << eprosima::fastcdr::MemberId(5) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeStatusImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.node_status();
-                        break;
+                                        case 0:
+                                                dcdr >> data.node_status();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.task_status();
-                        break;
+                                        case 1:
+                                                dcdr >> data.task_status();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.error_code();
-                        break;
+                                        case 2:
+                                                dcdr >> data.error_code();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.error_description();
-                        break;
+                                        case 3:
+                                                dcdr >> data.error_description();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.node_name();
-                        break;
+                                        case 4:
+                                                dcdr >> data.node_name();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 5:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -233,118 +228,118 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.node_name();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.node_name();
 
-            serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeControlImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.cmd_node(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.cmd_task(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.target_node(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.source_node(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeControlImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            return calculated_size;
-        }
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-                << eprosima::fastcdr::MemberId(2) << data.target_node()
-                << eprosima::fastcdr::MemberId(3) << data.source_node()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.cmd_node(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeControlImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.cmd_task(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.target_node(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.source_node(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+        << eprosima::fastcdr::MemberId(2) << data.target_node()
+        << eprosima::fastcdr::MemberId(3) << data.source_node()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeControlImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.cmd_node();
-                        break;
+                                        case 0:
+                                                dcdr >> data.cmd_node();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.cmd_task();
-                        break;
+                                        case 1:
+                                                dcdr >> data.cmd_task();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.target_node();
-                        break;
+                                        case 2:
+                                                dcdr >> data.target_node();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.source_node();
-                        break;
+                                        case 3:
+                                                dcdr >> data.source_node();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -352,198 +347,196 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.source_node();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.source_node();
 
-            serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const UserInputImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.modality(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const UserInputImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.problem_short_description(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.problem_definition(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.inputs(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.outputs(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.minimum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.maximum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.optimize_carbon_footprint_manual(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.previous_iteration(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                            data.optimize_carbon_footprint_auto(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                            data.desired_carbon_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                            data.geo_location_continent(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                            data.geo_location_region(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.modality(), current_alignment);
 
-            return calculated_size;
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.problem_short_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.problem_definition(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.modality()
-                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-                << eprosima::fastcdr::MemberId(3) << data.inputs()
-                << eprosima::fastcdr::MemberId(4) << data.outputs()
-                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-                << eprosima::fastcdr::MemberId(13) << data.extra_data()
-                << eprosima::fastcdr::MemberId(14) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.inputs(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                UserInputImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.outputs(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.minimum_samples(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.maximum_samples(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.optimize_carbon_footprint_manual(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.previous_iteration(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                data.optimize_carbon_footprint_auto(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                data.desired_carbon_footprint(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                data.geo_location_continent(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                data.geo_location_region(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                data.extra_data(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.modality()
+        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+        << eprosima::fastcdr::MemberId(3) << data.inputs()
+        << eprosima::fastcdr::MemberId(4) << data.outputs()
+        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+        << eprosima::fastcdr::MemberId(13) << data.extra_data()
+        << eprosima::fastcdr::MemberId(14) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        UserInputImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.modality();
-                        break;
+                                        case 0:
+                                                dcdr >> data.modality();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.problem_short_description();
-                        break;
+                                        case 1:
+                                                dcdr >> data.problem_short_description();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.problem_definition();
-                        break;
+                                        case 2:
+                                                dcdr >> data.problem_definition();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.inputs();
-                        break;
+                                        case 3:
+                                                dcdr >> data.inputs();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.outputs();
-                        break;
+                                        case 4:
+                                                dcdr >> data.outputs();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.minimum_samples();
-                        break;
+                                        case 5:
+                                                dcdr >> data.minimum_samples();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.maximum_samples();
-                        break;
+                                        case 6:
+                                                dcdr >> data.maximum_samples();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.optimize_carbon_footprint_manual();
-                        break;
+                                        case 7:
+                                                dcdr >> data.optimize_carbon_footprint_manual();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.previous_iteration();
-                        break;
+                                        case 8:
+                                                dcdr >> data.previous_iteration();
+                                            break;
 
-                    case 9:
-                        dcdr >> data.optimize_carbon_footprint_auto();
-                        break;
+                                        case 9:
+                                                dcdr >> data.optimize_carbon_footprint_auto();
+                                            break;
 
-                    case 10:
-                        dcdr >> data.desired_carbon_footprint();
-                        break;
+                                        case 10:
+                                                dcdr >> data.desired_carbon_footprint();
+                                            break;
 
-                    case 11:
-                        dcdr >> data.geo_location_continent();
-                        break;
+                                        case 11:
+                                                dcdr >> data.geo_location_continent();
+                                            break;
 
-                    case 12:
-                        dcdr >> data.geo_location_region();
-                        break;
+                                        case 12:
+                                                dcdr >> data.geo_location_region();
+                                            break;
 
-                    case 13:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 13:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 14:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 14:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -551,108 +544,106 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelMetadataImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.keywords(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelMetadataImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.ml_model_metadata(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.keywords(), current_alignment);
 
-            return calculated_size;
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.ml_model_metadata(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.keywords()
-                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-                << eprosima::fastcdr::MemberId(2) << data.extra_data()
-                << eprosima::fastcdr::MemberId(3) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelMetadataImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.keywords()
+        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelMetadataImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.keywords();
-                        break;
+                                        case 0:
+                                                dcdr >> data.keywords();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.ml_model_metadata();
-                        break;
+                                        case 1:
+                                                dcdr >> data.ml_model_metadata();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -660,100 +651,98 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const AppRequirementsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.app_requirements(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const AppRequirementsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.extra_data(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.task_id(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.app_requirements(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.extra_data(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.task_id(), current_alignment);
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-            return calculated_size;
-        }
+    return calculated_size;
+}
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-                << eprosima::fastcdr::MemberId(1) << data.extra_data()
-                << eprosima::fastcdr::MemberId(2) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+        << eprosima::fastcdr::MemberId(1) << data.extra_data()
+        << eprosima::fastcdr::MemberId(2) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                AppRequirementsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        AppRequirementsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.app_requirements();
-                        break;
+                                        case 0:
+                                                dcdr >> data.app_requirements();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -761,100 +750,106 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWConstraintsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.max_memory_footprint(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWConstraintsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.extra_data(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.task_id(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.max_memory_footprint(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.hardware_required(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-            return calculated_size;
-        }
+    return calculated_size;
+}
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.extra_data()
-                << eprosima::fastcdr::MemberId(2) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWConstraintsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWConstraintsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.max_memory_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.max_memory_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.hardware_required();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
+
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -862,148 +857,146 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.model_path(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.model(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.raw_model(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.model_properties_path(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.model_properties(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.input_batch(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.target_latency(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.model_path(), current_alignment);
 
-            return calculated_size;
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.raw_model(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.model_path()
-                << eprosima::fastcdr::MemberId(1) << data.model()
-                << eprosima::fastcdr::MemberId(2) << data.raw_model()
-                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-                << eprosima::fastcdr::MemberId(4) << data.model_properties()
-                << eprosima::fastcdr::MemberId(5) << data.input_batch()
-                << eprosima::fastcdr::MemberId(6) << data.target_latency()
-                << eprosima::fastcdr::MemberId(7) << data.extra_data()
-                << eprosima::fastcdr::MemberId(8) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.model_properties_path(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.model_properties(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.input_batch(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.target_latency(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.extra_data(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.model_path()
+        << eprosima::fastcdr::MemberId(1) << data.model()
+        << eprosima::fastcdr::MemberId(2) << data.raw_model()
+        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+        << eprosima::fastcdr::MemberId(4) << data.model_properties()
+        << eprosima::fastcdr::MemberId(5) << data.input_batch()
+        << eprosima::fastcdr::MemberId(6) << data.target_latency()
+        << eprosima::fastcdr::MemberId(7) << data.extra_data()
+        << eprosima::fastcdr::MemberId(8) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.model_path();
-                        break;
+                                        case 0:
+                                                dcdr >> data.model_path();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.model();
-                        break;
+                                        case 1:
+                                                dcdr >> data.model();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.raw_model();
-                        break;
+                                        case 2:
+                                                dcdr >> data.raw_model();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.model_properties_path();
-                        break;
+                                        case 3:
+                                                dcdr >> data.model_properties_path();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.model_properties();
-                        break;
+                                        case 4:
+                                                dcdr >> data.model_properties();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.input_batch();
-                        break;
+                                        case 5:
+                                                dcdr >> data.input_batch();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.target_latency();
-                        break;
+                                        case 6:
+                                                dcdr >> data.target_latency();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 7:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 8:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1011,132 +1004,130 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWResourceImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.hw_description(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWResourceImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.power_consumption(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.latency(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.memory_footprint_of_ml_model(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.max_hw_memory_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.hw_description(), current_alignment);
 
-            return calculated_size;
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.power_consumption(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.latency(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.hw_description()
-                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.latency()
-                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-                << eprosima::fastcdr::MemberId(5) << data.extra_data()
-                << eprosima::fastcdr::MemberId(6) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.memory_footprint_of_ml_model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWResourceImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.max_hw_memory_footprint(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.extra_data(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.hw_description()
+        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.latency()
+        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+        << eprosima::fastcdr::MemberId(5) << data.extra_data()
+        << eprosima::fastcdr::MemberId(6) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWResourceImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.hw_description();
-                        break;
+                                        case 0:
+                                                dcdr >> data.hw_description();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.power_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.power_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.latency();
-                        break;
+                                        case 2:
+                                                dcdr >> data.latency();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.memory_footprint_of_ml_model();
-                        break;
+                                        case 3:
+                                                dcdr >> data.memory_footprint_of_ml_model();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.max_hw_memory_footprint();
-                        break;
+                                        case 4:
+                                                dcdr >> data.max_hw_memory_footprint();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 5:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 6:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1144,116 +1135,114 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const CO2FootprintImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+}
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.carbon_footprint(), current_alignment);
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const CO2FootprintImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.energy_consumption(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.carbon_intensity(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.carbon_footprint(), current_alignment);
 
-            return calculated_size;
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.energy_consumption(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.carbon_intensity(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-                << eprosima::fastcdr::MemberId(3) << data.extra_data()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.extra_data(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                CO2FootprintImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+        << eprosima::fastcdr::MemberId(3) << data.extra_data()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        CO2FootprintImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.carbon_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.carbon_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.energy_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.energy_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.carbon_intensity();
-                        break;
+                                        case 2:
+                                                dcdr >> data.carbon_intensity();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 3:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1261,24 +1250,26 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
-        }
+}
 
-    } // namespace fastcdr
+
+
+} // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
@@ -32,66 +32,66 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-    namespace fastcdr {
+namespace fastcdr {
 
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const TaskIdImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const TaskIdImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
-
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.problem_id(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.iteration_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.problem_id(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.iteration_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.problem_id()
-                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                TaskIdImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.problem_id()
+        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        TaskIdImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -110,95 +110,95 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.problem_id();
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.problem_id();
 
-            scdr << data.iteration_id();
+    scdr << data.iteration_id();
 
-        }
+}
 
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeStatusImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeStatusImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
-
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.node_status(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.task_status(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.error_code(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.error_description(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.node_name(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.node_status(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.task_status(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.error_code(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.node_status()
-                << eprosima::fastcdr::MemberId(1) << data.task_status()
-                << eprosima::fastcdr::MemberId(2) << data.error_code()
-                << eprosima::fastcdr::MemberId(3) << data.error_description()
-                << eprosima::fastcdr::MemberId(4) << data.node_name()
-                << eprosima::fastcdr::MemberId(5) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.error_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeStatusImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.node_name(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.node_status()
+        << eprosima::fastcdr::MemberId(1) << data.task_status()
+        << eprosima::fastcdr::MemberId(2) << data.error_code()
+        << eprosima::fastcdr::MemberId(3) << data.error_description()
+        << eprosima::fastcdr::MemberId(4) << data.node_name()
+        << eprosima::fastcdr::MemberId(5) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeStatusImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -233,95 +233,95 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.node_name();
-
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeControlImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.cmd_node(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.node_name();
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.cmd_task(), current_alignment);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.target_node(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.source_node(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeControlImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.cmd_node(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.cmd_task(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.target_node(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-                << eprosima::fastcdr::MemberId(2) << data.target_node()
-                << eprosima::fastcdr::MemberId(3) << data.source_node()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.source_node(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeControlImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+        << eprosima::fastcdr::MemberId(2) << data.target_node()
+        << eprosima::fastcdr::MemberId(3) << data.source_node()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeControlImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -352,135 +352,135 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.source_node();
-
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const UserInputImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.modality(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.source_node();
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.problem_short_description(), current_alignment);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.problem_definition(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.inputs(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const UserInputImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.outputs(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.minimum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.maximum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.optimize_carbon_footprint_manual(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.previous_iteration(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                            data.optimize_carbon_footprint_auto(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                            data.desired_carbon_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                            data.geo_location_continent(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                            data.geo_location_region(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.modality(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.problem_short_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.problem_definition(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.modality()
-                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-                << eprosima::fastcdr::MemberId(3) << data.inputs()
-                << eprosima::fastcdr::MemberId(4) << data.outputs()
-                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-                << eprosima::fastcdr::MemberId(13) << data.extra_data()
-                << eprosima::fastcdr::MemberId(14) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.inputs(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                UserInputImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.outputs(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.minimum_samples(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.maximum_samples(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    data.optimize_carbon_footprint_manual(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    data.previous_iteration(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                    data.optimize_carbon_footprint_auto(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                    data.desired_carbon_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                    data.geo_location_continent(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                    data.geo_location_region(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.modality()
+        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+        << eprosima::fastcdr::MemberId(3) << data.inputs()
+        << eprosima::fastcdr::MemberId(4) << data.outputs()
+        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+        << eprosima::fastcdr::MemberId(13) << data.extra_data()
+        << eprosima::fastcdr::MemberId(14) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        UserInputImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -551,89 +551,89 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelMetadataImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.keywords(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.ml_model_metadata(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.extra_data(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelMetadataImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.keywords(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.ml_model_metadata(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.extra_data(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.keywords()
-                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-                << eprosima::fastcdr::MemberId(2) << data.extra_data()
-                << eprosima::fastcdr::MemberId(3) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.task_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelMetadataImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.keywords()
+        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelMetadataImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -660,85 +660,85 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const AppRequirementsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.app_requirements(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.extra_data(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.task_id(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const AppRequirementsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.app_requirements(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.extra_data(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.task_id(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-                << eprosima::fastcdr::MemberId(1) << data.extra_data()
-                << eprosima::fastcdr::MemberId(2) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                AppRequirementsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+        << eprosima::fastcdr::MemberId(1) << data.extra_data()
+        << eprosima::fastcdr::MemberId(2) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        AppRequirementsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -761,89 +761,89 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWConstraintsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.max_memory_footprint(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.hardware_required(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.extra_data(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWConstraintsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.max_memory_footprint(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.hardware_required(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.extra_data(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.hardware_required()
-                << eprosima::fastcdr::MemberId(2) << data.extra_data()
-                << eprosima::fastcdr::MemberId(3) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.task_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWConstraintsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWConstraintsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -870,109 +870,109 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.model_path(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.model(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.raw_model(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.model_properties_path(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.model_properties(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.input_batch(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.target_latency(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.model_path(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.raw_model(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.model_path()
-                << eprosima::fastcdr::MemberId(1) << data.model()
-                << eprosima::fastcdr::MemberId(2) << data.raw_model()
-                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-                << eprosima::fastcdr::MemberId(4) << data.model_properties()
-                << eprosima::fastcdr::MemberId(5) << data.input_batch()
-                << eprosima::fastcdr::MemberId(6) << data.target_latency()
-                << eprosima::fastcdr::MemberId(7) << data.extra_data()
-                << eprosima::fastcdr::MemberId(8) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.model_properties_path(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.model_properties(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.input_batch(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.target_latency(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.model_path()
+        << eprosima::fastcdr::MemberId(1) << data.model()
+        << eprosima::fastcdr::MemberId(2) << data.raw_model()
+        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+        << eprosima::fastcdr::MemberId(4) << data.model_properties()
+        << eprosima::fastcdr::MemberId(5) << data.input_batch()
+        << eprosima::fastcdr::MemberId(6) << data.target_latency()
+        << eprosima::fastcdr::MemberId(7) << data.extra_data()
+        << eprosima::fastcdr::MemberId(8) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1019,101 +1019,101 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWResourceImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.hw_description(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.power_consumption(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.latency(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWResourceImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.memory_footprint_of_ml_model(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.max_hw_memory_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.hw_description(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.power_consumption(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.latency(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.hw_description()
-                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.latency()
-                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-                << eprosima::fastcdr::MemberId(5) << data.extra_data()
-                << eprosima::fastcdr::MemberId(6) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.memory_footprint_of_ml_model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWResourceImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.max_hw_memory_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.hw_description()
+        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.latency()
+        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+        << eprosima::fastcdr::MemberId(5) << data.extra_data()
+        << eprosima::fastcdr::MemberId(6) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWResourceImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1152,93 +1152,93 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const CO2FootprintImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.carbon_footprint(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.energy_consumption(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.carbon_intensity(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const CO2FootprintImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.extra_data(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.carbon_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.energy_consumption(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.carbon_intensity(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.task_id(), current_alignment);
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-            return calculated_size;
-        }
+    return calculated_size;
+}
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-                << eprosima::fastcdr::MemberId(3) << data.extra_data()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+        << eprosima::fastcdr::MemberId(3) << data.extra_data()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                CO2FootprintImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        CO2FootprintImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1269,24 +1269,24 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-        }
+}
 
-    } // namespace fastcdr
+}     // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
@@ -32,74 +32,77 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-namespace fastcdr {
+    namespace fastcdr {
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const TaskIdImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const TaskIdImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.problem_id(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.iteration_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.problem_id(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.iteration_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.problem_id()
-        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        TaskIdImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.problem_id()
+                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                TaskIdImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.problem_id();
-                                            break;
+                    case 0:
+                        dcdr >> data.problem_id();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.iteration_id();
-                                            break;
+                    case 1:
+                        dcdr >> data.iteration_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -107,120 +110,122 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.problem_id();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.problem_id();
 
-                        scdr << data.iteration_id();
+            scdr << data.iteration_id();
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeStatusImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeStatusImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.node_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.task_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.error_code(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.error_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.node_name(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.node_status(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.task_status(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.error_code(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.node_status()
-        << eprosima::fastcdr::MemberId(1) << data.task_status()
-        << eprosima::fastcdr::MemberId(2) << data.error_code()
-        << eprosima::fastcdr::MemberId(3) << data.error_description()
-        << eprosima::fastcdr::MemberId(4) << data.node_name()
-        << eprosima::fastcdr::MemberId(5) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.error_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeStatusImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.node_name(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.node_status()
+                << eprosima::fastcdr::MemberId(1) << data.task_status()
+                << eprosima::fastcdr::MemberId(2) << data.error_code()
+                << eprosima::fastcdr::MemberId(3) << data.error_description()
+                << eprosima::fastcdr::MemberId(4) << data.node_name()
+                << eprosima::fastcdr::MemberId(5) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeStatusImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.node_status();
-                                            break;
+                    case 0:
+                        dcdr >> data.node_status();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.task_status();
-                                            break;
+                    case 1:
+                        dcdr >> data.task_status();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.error_code();
-                                            break;
+                    case 2:
+                        dcdr >> data.error_code();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.error_description();
-                                            break;
+                    case 3:
+                        dcdr >> data.error_description();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.node_name();
-                                            break;
+                    case 4:
+                        dcdr >> data.node_name();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 5:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -228,118 +233,118 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.node_name();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.node_name();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeControlImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-
-
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeControlImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.cmd_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.cmd_task(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.target_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.source_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.cmd_node(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.cmd_task(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.target_node(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-        << eprosima::fastcdr::MemberId(2) << data.target_node()
-        << eprosima::fastcdr::MemberId(3) << data.source_node()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.source_node(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeControlImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+                << eprosima::fastcdr::MemberId(2) << data.target_node()
+                << eprosima::fastcdr::MemberId(3) << data.source_node()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeControlImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.cmd_node();
-                                            break;
+                    case 0:
+                        dcdr >> data.cmd_node();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.cmd_task();
-                                            break;
+                    case 1:
+                        dcdr >> data.cmd_task();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.target_node();
-                                            break;
+                    case 2:
+                        dcdr >> data.target_node();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.source_node();
-                                            break;
+                    case 3:
+                        dcdr >> data.source_node();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -347,196 +352,198 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.source_node();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.source_node();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const UserInputImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const UserInputImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.modality(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.problem_short_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.problem_definition(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.inputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.outputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.minimum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.maximum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.optimize_carbon_footprint_manual(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.previous_iteration(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                data.optimize_carbon_footprint_auto(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                data.desired_carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                data.geo_location_continent(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                data.geo_location_region(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.modality(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.problem_short_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.problem_definition(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.modality()
-        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-        << eprosima::fastcdr::MemberId(3) << data.inputs()
-        << eprosima::fastcdr::MemberId(4) << data.outputs()
-        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-        << eprosima::fastcdr::MemberId(13) << data.extra_data()
-        << eprosima::fastcdr::MemberId(14) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.inputs(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        UserInputImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.outputs(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.minimum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.maximum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.optimize_carbon_footprint_manual(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.previous_iteration(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                            data.optimize_carbon_footprint_auto(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                            data.desired_carbon_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                            data.geo_location_continent(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                            data.geo_location_region(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.modality()
+                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+                << eprosima::fastcdr::MemberId(3) << data.inputs()
+                << eprosima::fastcdr::MemberId(4) << data.outputs()
+                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+                << eprosima::fastcdr::MemberId(13) << data.extra_data()
+                << eprosima::fastcdr::MemberId(14) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                UserInputImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.modality();
-                                            break;
+                    case 0:
+                        dcdr >> data.modality();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.problem_short_description();
-                                            break;
+                    case 1:
+                        dcdr >> data.problem_short_description();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.problem_definition();
-                                            break;
+                    case 2:
+                        dcdr >> data.problem_definition();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.inputs();
-                                            break;
+                    case 3:
+                        dcdr >> data.inputs();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.outputs();
-                                            break;
+                    case 4:
+                        dcdr >> data.outputs();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.minimum_samples();
-                                            break;
+                    case 5:
+                        dcdr >> data.minimum_samples();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.maximum_samples();
-                                            break;
+                    case 6:
+                        dcdr >> data.maximum_samples();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.optimize_carbon_footprint_manual();
-                                            break;
+                    case 7:
+                        dcdr >> data.optimize_carbon_footprint_manual();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.previous_iteration();
-                                            break;
+                    case 8:
+                        dcdr >> data.previous_iteration();
+                        break;
 
-                                        case 9:
-                                                dcdr >> data.optimize_carbon_footprint_auto();
-                                            break;
+                    case 9:
+                        dcdr >> data.optimize_carbon_footprint_auto();
+                        break;
 
-                                        case 10:
-                                                dcdr >> data.desired_carbon_footprint();
-                                            break;
+                    case 10:
+                        dcdr >> data.desired_carbon_footprint();
+                        break;
 
-                                        case 11:
-                                                dcdr >> data.geo_location_continent();
-                                            break;
+                    case 11:
+                        dcdr >> data.geo_location_continent();
+                        break;
 
-                                        case 12:
-                                                dcdr >> data.geo_location_region();
-                                            break;
+                    case 12:
+                        dcdr >> data.geo_location_region();
+                        break;
 
-                                        case 13:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 13:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 14:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 14:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -544,106 +551,108 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelMetadataImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelMetadataImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.keywords(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.ml_model_metadata(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.keywords(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.ml_model_metadata(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.extra_data(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.keywords()
-        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-        << eprosima::fastcdr::MemberId(2) << data.extra_data()
-        << eprosima::fastcdr::MemberId(3) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.task_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelMetadataImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.keywords()
+                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+                << eprosima::fastcdr::MemberId(2) << data.extra_data()
+                << eprosima::fastcdr::MemberId(3) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelMetadataImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.keywords();
-                                            break;
+                    case 0:
+                        dcdr >> data.keywords();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.ml_model_metadata();
-                                            break;
+                    case 1:
+                        dcdr >> data.ml_model_metadata();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 2:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 3:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -651,98 +660,100 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const AppRequirementsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const AppRequirementsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.app_requirements(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.app_requirements(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.task_id(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-        << eprosima::fastcdr::MemberId(1) << data.extra_data()
-        << eprosima::fastcdr::MemberId(2) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        AppRequirementsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+                << eprosima::fastcdr::MemberId(1) << data.extra_data()
+                << eprosima::fastcdr::MemberId(2) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                AppRequirementsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.app_requirements();
-                                            break;
+                    case 0:
+                        dcdr >> data.app_requirements();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 1:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 2:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -750,98 +761,100 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWConstraintsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWConstraintsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.max_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.max_memory_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.task_id(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.extra_data()
-        << eprosima::fastcdr::MemberId(2) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWConstraintsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.extra_data()
+                << eprosima::fastcdr::MemberId(2) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWConstraintsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.max_memory_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.max_memory_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 1:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 2:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -849,146 +862,148 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.model_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.raw_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.model_properties_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.model_properties(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.input_batch(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.target_latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.model_path(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.raw_model(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.model_path()
-        << eprosima::fastcdr::MemberId(1) << data.model()
-        << eprosima::fastcdr::MemberId(2) << data.raw_model()
-        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-        << eprosima::fastcdr::MemberId(4) << data.model_properties()
-        << eprosima::fastcdr::MemberId(5) << data.input_batch()
-        << eprosima::fastcdr::MemberId(6) << data.target_latency()
-        << eprosima::fastcdr::MemberId(7) << data.extra_data()
-        << eprosima::fastcdr::MemberId(8) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.model_properties_path(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.model_properties(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.input_batch(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.target_latency(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.model_path()
+                << eprosima::fastcdr::MemberId(1) << data.model()
+                << eprosima::fastcdr::MemberId(2) << data.raw_model()
+                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+                << eprosima::fastcdr::MemberId(4) << data.model_properties()
+                << eprosima::fastcdr::MemberId(5) << data.input_batch()
+                << eprosima::fastcdr::MemberId(6) << data.target_latency()
+                << eprosima::fastcdr::MemberId(7) << data.extra_data()
+                << eprosima::fastcdr::MemberId(8) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.model_path();
-                                            break;
+                    case 0:
+                        dcdr >> data.model_path();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.model();
-                                            break;
+                    case 1:
+                        dcdr >> data.model();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.raw_model();
-                                            break;
+                    case 2:
+                        dcdr >> data.raw_model();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.model_properties_path();
-                                            break;
+                    case 3:
+                        dcdr >> data.model_properties_path();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.model_properties();
-                                            break;
+                    case 4:
+                        dcdr >> data.model_properties();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.input_batch();
-                                            break;
+                    case 5:
+                        dcdr >> data.input_batch();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.target_latency();
-                                            break;
+                    case 6:
+                        dcdr >> data.target_latency();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 7:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 8:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -996,130 +1011,132 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWResourceImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWResourceImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.hw_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.power_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.memory_footprint_of_ml_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.max_hw_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.hw_description(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.power_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.latency(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.hw_description()
-        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.latency()
-        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-        << eprosima::fastcdr::MemberId(5) << data.extra_data()
-        << eprosima::fastcdr::MemberId(6) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.memory_footprint_of_ml_model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWResourceImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.max_hw_memory_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.hw_description()
+                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.latency()
+                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+                << eprosima::fastcdr::MemberId(5) << data.extra_data()
+                << eprosima::fastcdr::MemberId(6) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWResourceImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.hw_description();
-                                            break;
+                    case 0:
+                        dcdr >> data.hw_description();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.power_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.power_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.latency();
-                                            break;
+                    case 2:
+                        dcdr >> data.latency();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.memory_footprint_of_ml_model();
-                                            break;
+                    case 3:
+                        dcdr >> data.memory_footprint_of_ml_model();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.max_hw_memory_footprint();
-                                            break;
+                    case 4:
+                        dcdr >> data.max_hw_memory_footprint();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 5:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 6:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1127,114 +1144,116 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const CO2FootprintImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const CO2FootprintImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.energy_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.carbon_intensity(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.carbon_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.energy_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.carbon_intensity(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-        << eprosima::fastcdr::MemberId(3) << data.extra_data()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        CO2FootprintImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+                << eprosima::fastcdr::MemberId(3) << data.extra_data()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                CO2FootprintImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.carbon_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.carbon_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.energy_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.energy_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.carbon_intensity();
-                                            break;
+                    case 2:
+                        dcdr >> data.carbon_intensity();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 3:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1242,26 +1261,24 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
-
-
-} // namespace fastcdr
+    } // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
@@ -50,11 +50,11 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.problem_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.problem_id(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.iteration_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.iteration_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -76,7 +76,7 @@ eProsima_user_DllExport void serialize(
     scdr
         << eprosima::fastcdr::MemberId(0) << data.problem_id()
         << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -93,13 +93,13 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.problem_id();
-                        break;
+                                        case 0:
+                                                dcdr >> data.problem_id();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.iteration_id();
-                        break;
+                                        case 1:
+                                                dcdr >> data.iteration_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -116,11 +116,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.problem_id();
+                        scdr << data.problem_id();
 
-    scdr << data.iteration_id();
+                        scdr << data.iteration_id();
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -138,23 +139,23 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.node_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.task_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.task_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.error_code(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.error_code(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.error_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.error_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.node_name(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.node_name(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -180,7 +181,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(3) << data.error_description()
         << eprosima::fastcdr::MemberId(4) << data.node_name()
         << eprosima::fastcdr::MemberId(5) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -197,29 +198,29 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.node_status();
-                        break;
+                                        case 0:
+                                                dcdr >> data.node_status();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.task_status();
-                        break;
+                                        case 1:
+                                                dcdr >> data.task_status();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.error_code();
-                        break;
+                                        case 2:
+                                                dcdr >> data.error_code();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.error_description();
-                        break;
+                                        case 3:
+                                                dcdr >> data.error_description();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.node_name();
-                        break;
+                                        case 4:
+                                                dcdr >> data.node_name();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 5:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -233,18 +234,21 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.node_name();
+                        scdr << data.node_name();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
+
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -262,20 +266,20 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.cmd_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.cmd_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.cmd_task(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.cmd_task(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.target_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.target_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.source_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.source_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -300,7 +304,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.target_node()
         << eprosima::fastcdr::MemberId(3) << data.source_node()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -317,25 +321,25 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.cmd_node();
-                        break;
+                                        case 0:
+                                                dcdr >> data.cmd_node();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.cmd_task();
-                        break;
+                                        case 1:
+                                                dcdr >> data.cmd_task();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.target_node();
-                        break;
+                                        case 2:
+                                                dcdr >> data.target_node();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.source_node();
-                        break;
+                                        case 3:
+                                                dcdr >> data.source_node();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -349,18 +353,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.source_node();
+                        scdr << data.source_node();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -378,50 +383,50 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.modality(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.modality(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.problem_short_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.problem_short_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.problem_definition(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.problem_definition(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.inputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.inputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.outputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.outputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.minimum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.minimum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.maximum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.maximum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.optimize_carbon_footprint_manual(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.optimize_carbon_footprint_manual(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.previous_iteration(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.previous_iteration(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                    data.optimize_carbon_footprint_auto(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                data.optimize_carbon_footprint_auto(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                    data.desired_carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                data.desired_carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                    data.geo_location_continent(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                data.geo_location_continent(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                    data.geo_location_region(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                data.geo_location_region(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -456,7 +461,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
         << eprosima::fastcdr::MemberId(13) << data.extra_data()
         << eprosima::fastcdr::MemberId(14) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -473,65 +478,65 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.modality();
-                        break;
+                                        case 0:
+                                                dcdr >> data.modality();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.problem_short_description();
-                        break;
+                                        case 1:
+                                                dcdr >> data.problem_short_description();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.problem_definition();
-                        break;
+                                        case 2:
+                                                dcdr >> data.problem_definition();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.inputs();
-                        break;
+                                        case 3:
+                                                dcdr >> data.inputs();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.outputs();
-                        break;
+                                        case 4:
+                                                dcdr >> data.outputs();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.minimum_samples();
-                        break;
+                                        case 5:
+                                                dcdr >> data.minimum_samples();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.maximum_samples();
-                        break;
+                                        case 6:
+                                                dcdr >> data.maximum_samples();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.optimize_carbon_footprint_manual();
-                        break;
+                                        case 7:
+                                                dcdr >> data.optimize_carbon_footprint_manual();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.previous_iteration();
-                        break;
+                                        case 8:
+                                                dcdr >> data.previous_iteration();
+                                            break;
 
-                    case 9:
-                        dcdr >> data.optimize_carbon_footprint_auto();
-                        break;
+                                        case 9:
+                                                dcdr >> data.optimize_carbon_footprint_auto();
+                                            break;
 
-                    case 10:
-                        dcdr >> data.desired_carbon_footprint();
-                        break;
+                                        case 10:
+                                                dcdr >> data.desired_carbon_footprint();
+                                            break;
 
-                    case 11:
-                        dcdr >> data.geo_location_continent();
-                        break;
+                                        case 11:
+                                                dcdr >> data.geo_location_continent();
+                                            break;
 
-                    case 12:
-                        dcdr >> data.geo_location_region();
-                        break;
+                                        case 12:
+                                                dcdr >> data.geo_location_region();
+                                            break;
 
-                    case 13:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 13:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 14:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 14:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -545,16 +550,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UserInputImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -572,17 +578,17 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.keywords(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.keywords(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.ml_model_metadata(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.ml_model_metadata(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -606,7 +612,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
         << eprosima::fastcdr::MemberId(2) << data.extra_data()
         << eprosima::fastcdr::MemberId(3) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -623,21 +629,21 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.keywords();
-                        break;
+                                        case 0:
+                                                dcdr >> data.keywords();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.ml_model_metadata();
-                        break;
+                                        case 1:
+                                                dcdr >> data.ml_model_metadata();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -651,16 +657,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelMetadataImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -678,14 +685,14 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.app_requirements(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.app_requirements(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -708,7 +715,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(0) << data.app_requirements()
         << eprosima::fastcdr::MemberId(1) << data.extra_data()
         << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -725,17 +732,17 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.app_requirements();
-                        break;
+                                        case 0:
+                                                dcdr >> data.app_requirements();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -749,16 +756,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppRequirementsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -776,14 +784,14 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.max_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.max_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -806,7 +814,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
         << eprosima::fastcdr::MemberId(1) << data.extra_data()
         << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -823,17 +831,17 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.max_memory_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.max_memory_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -847,16 +855,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWConstraintsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -874,32 +883,32 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.model_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.model_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.raw_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.raw_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.model_properties_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.model_properties_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.model_properties(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.model_properties(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.input_batch(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.input_batch(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.target_latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.target_latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -928,7 +937,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(6) << data.target_latency()
         << eprosima::fastcdr::MemberId(7) << data.extra_data()
         << eprosima::fastcdr::MemberId(8) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -945,41 +954,41 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.model_path();
-                        break;
+                                        case 0:
+                                                dcdr >> data.model_path();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.model();
-                        break;
+                                        case 1:
+                                                dcdr >> data.model();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.raw_model();
-                        break;
+                                        case 2:
+                                                dcdr >> data.raw_model();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.model_properties_path();
-                        break;
+                                        case 3:
+                                                dcdr >> data.model_properties_path();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.model_properties();
-                        break;
+                                        case 4:
+                                                dcdr >> data.model_properties();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.input_batch();
-                        break;
+                                        case 5:
+                                                dcdr >> data.input_batch();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.target_latency();
-                        break;
+                                        case 6:
+                                                dcdr >> data.target_latency();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 7:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 8:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -993,16 +1002,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -1020,26 +1030,26 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.hw_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.hw_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.power_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.power_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.memory_footprint_of_ml_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.memory_footprint_of_ml_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.max_hw_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.max_hw_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1066,7 +1076,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
         << eprosima::fastcdr::MemberId(5) << data.extra_data()
         << eprosima::fastcdr::MemberId(6) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -1083,33 +1093,33 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.hw_description();
-                        break;
+                                        case 0:
+                                                dcdr >> data.hw_description();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.power_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.power_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.latency();
-                        break;
+                                        case 2:
+                                                dcdr >> data.latency();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.memory_footprint_of_ml_model();
-                        break;
+                                        case 3:
+                                                dcdr >> data.memory_footprint_of_ml_model();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.max_hw_memory_footprint();
-                        break;
+                                        case 4:
+                                                dcdr >> data.max_hw_memory_footprint();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 5:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 6:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1123,16 +1133,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWResourceImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -1150,20 +1161,20 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.energy_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.energy_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.carbon_intensity(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.carbon_intensity(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1188,7 +1199,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
         << eprosima::fastcdr::MemberId(3) << data.extra_data()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -1205,25 +1216,25 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.carbon_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.carbon_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.energy_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.energy_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.carbon_intensity();
-                        break;
+                                        case 2:
+                                                dcdr >> data.carbon_intensity();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 3:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1237,16 +1248,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
+
 
 } // namespace fastcdr
 } // namespace eprosima

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
@@ -32,74 +32,77 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-namespace fastcdr {
+    namespace fastcdr {
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const TaskIdImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const TaskIdImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.problem_id(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.iteration_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.problem_id(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.iteration_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.problem_id()
-        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        TaskIdImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.problem_id()
+                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                TaskIdImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.problem_id();
-                                            break;
+                    case 0:
+                        dcdr >> data.problem_id();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.iteration_id();
-                                            break;
+                    case 1:
+                        dcdr >> data.iteration_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -107,120 +110,122 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.problem_id();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.problem_id();
 
-                        scdr << data.iteration_id();
+            scdr << data.iteration_id();
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeStatusImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeStatusImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.node_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.task_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.error_code(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.error_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.node_name(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.node_status(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.task_status(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.error_code(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.node_status()
-        << eprosima::fastcdr::MemberId(1) << data.task_status()
-        << eprosima::fastcdr::MemberId(2) << data.error_code()
-        << eprosima::fastcdr::MemberId(3) << data.error_description()
-        << eprosima::fastcdr::MemberId(4) << data.node_name()
-        << eprosima::fastcdr::MemberId(5) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.error_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeStatusImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.node_name(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.node_status()
+                << eprosima::fastcdr::MemberId(1) << data.task_status()
+                << eprosima::fastcdr::MemberId(2) << data.error_code()
+                << eprosima::fastcdr::MemberId(3) << data.error_description()
+                << eprosima::fastcdr::MemberId(4) << data.node_name()
+                << eprosima::fastcdr::MemberId(5) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeStatusImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.node_status();
-                                            break;
+                    case 0:
+                        dcdr >> data.node_status();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.task_status();
-                                            break;
+                    case 1:
+                        dcdr >> data.task_status();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.error_code();
-                                            break;
+                    case 2:
+                        dcdr >> data.error_code();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.error_description();
-                                            break;
+                    case 3:
+                        dcdr >> data.error_description();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.node_name();
-                                            break;
+                    case 4:
+                        dcdr >> data.node_name();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 5:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -228,118 +233,118 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.node_name();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.node_name();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeControlImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-
-
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeControlImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.cmd_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.cmd_task(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.target_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.source_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.cmd_node(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.cmd_task(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.target_node(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-        << eprosima::fastcdr::MemberId(2) << data.target_node()
-        << eprosima::fastcdr::MemberId(3) << data.source_node()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.source_node(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeControlImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+                << eprosima::fastcdr::MemberId(2) << data.target_node()
+                << eprosima::fastcdr::MemberId(3) << data.source_node()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeControlImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.cmd_node();
-                                            break;
+                    case 0:
+                        dcdr >> data.cmd_node();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.cmd_task();
-                                            break;
+                    case 1:
+                        dcdr >> data.cmd_task();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.target_node();
-                                            break;
+                    case 2:
+                        dcdr >> data.target_node();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.source_node();
-                                            break;
+                    case 3:
+                        dcdr >> data.source_node();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -347,196 +352,198 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.source_node();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.source_node();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const UserInputImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const UserInputImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.modality(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.problem_short_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.problem_definition(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.inputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.outputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.minimum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.maximum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.optimize_carbon_footprint_manual(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.previous_iteration(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                data.optimize_carbon_footprint_auto(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                data.desired_carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                data.geo_location_continent(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                data.geo_location_region(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.modality(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.problem_short_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.problem_definition(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.modality()
-        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-        << eprosima::fastcdr::MemberId(3) << data.inputs()
-        << eprosima::fastcdr::MemberId(4) << data.outputs()
-        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-        << eprosima::fastcdr::MemberId(13) << data.extra_data()
-        << eprosima::fastcdr::MemberId(14) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.inputs(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        UserInputImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.outputs(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.minimum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.maximum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.optimize_carbon_footprint_manual(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.previous_iteration(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                            data.optimize_carbon_footprint_auto(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                            data.desired_carbon_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                            data.geo_location_continent(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                            data.geo_location_region(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.modality()
+                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+                << eprosima::fastcdr::MemberId(3) << data.inputs()
+                << eprosima::fastcdr::MemberId(4) << data.outputs()
+                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+                << eprosima::fastcdr::MemberId(13) << data.extra_data()
+                << eprosima::fastcdr::MemberId(14) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                UserInputImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.modality();
-                                            break;
+                    case 0:
+                        dcdr >> data.modality();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.problem_short_description();
-                                            break;
+                    case 1:
+                        dcdr >> data.problem_short_description();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.problem_definition();
-                                            break;
+                    case 2:
+                        dcdr >> data.problem_definition();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.inputs();
-                                            break;
+                    case 3:
+                        dcdr >> data.inputs();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.outputs();
-                                            break;
+                    case 4:
+                        dcdr >> data.outputs();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.minimum_samples();
-                                            break;
+                    case 5:
+                        dcdr >> data.minimum_samples();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.maximum_samples();
-                                            break;
+                    case 6:
+                        dcdr >> data.maximum_samples();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.optimize_carbon_footprint_manual();
-                                            break;
+                    case 7:
+                        dcdr >> data.optimize_carbon_footprint_manual();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.previous_iteration();
-                                            break;
+                    case 8:
+                        dcdr >> data.previous_iteration();
+                        break;
 
-                                        case 9:
-                                                dcdr >> data.optimize_carbon_footprint_auto();
-                                            break;
+                    case 9:
+                        dcdr >> data.optimize_carbon_footprint_auto();
+                        break;
 
-                                        case 10:
-                                                dcdr >> data.desired_carbon_footprint();
-                                            break;
+                    case 10:
+                        dcdr >> data.desired_carbon_footprint();
+                        break;
 
-                                        case 11:
-                                                dcdr >> data.geo_location_continent();
-                                            break;
+                    case 11:
+                        dcdr >> data.geo_location_continent();
+                        break;
 
-                                        case 12:
-                                                dcdr >> data.geo_location_region();
-                                            break;
+                    case 12:
+                        dcdr >> data.geo_location_region();
+                        break;
 
-                                        case 13:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 13:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 14:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 14:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -544,106 +551,108 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelMetadataImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelMetadataImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.keywords(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.ml_model_metadata(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.keywords(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.ml_model_metadata(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.extra_data(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.keywords()
-        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-        << eprosima::fastcdr::MemberId(2) << data.extra_data()
-        << eprosima::fastcdr::MemberId(3) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.task_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelMetadataImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.keywords()
+                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+                << eprosima::fastcdr::MemberId(2) << data.extra_data()
+                << eprosima::fastcdr::MemberId(3) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelMetadataImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.keywords();
-                                            break;
+                    case 0:
+                        dcdr >> data.keywords();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.ml_model_metadata();
-                                            break;
+                    case 1:
+                        dcdr >> data.ml_model_metadata();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 2:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 3:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -651,98 +660,100 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const AppRequirementsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const AppRequirementsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.app_requirements(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.app_requirements(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.task_id(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-        << eprosima::fastcdr::MemberId(1) << data.extra_data()
-        << eprosima::fastcdr::MemberId(2) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        AppRequirementsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+                << eprosima::fastcdr::MemberId(1) << data.extra_data()
+                << eprosima::fastcdr::MemberId(2) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                AppRequirementsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.app_requirements();
-                                            break;
+                    case 0:
+                        dcdr >> data.app_requirements();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 1:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 2:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -750,106 +761,108 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWConstraintsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWConstraintsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.max_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.hardware_required(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.max_memory_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.hardware_required(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.extra_data(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
-        << eprosima::fastcdr::MemberId(2) << data.extra_data()
-        << eprosima::fastcdr::MemberId(3) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.task_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWConstraintsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+                << eprosima::fastcdr::MemberId(2) << data.extra_data()
+                << eprosima::fastcdr::MemberId(3) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWConstraintsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.max_memory_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.max_memory_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.hardware_required();
-                                            break;
+                    case 1:
+                        dcdr >> data.hardware_required();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 2:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 3:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -857,146 +870,148 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.model_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.raw_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.model_properties_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.model_properties(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.input_batch(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.target_latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.model_path(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.raw_model(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.model_path()
-        << eprosima::fastcdr::MemberId(1) << data.model()
-        << eprosima::fastcdr::MemberId(2) << data.raw_model()
-        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-        << eprosima::fastcdr::MemberId(4) << data.model_properties()
-        << eprosima::fastcdr::MemberId(5) << data.input_batch()
-        << eprosima::fastcdr::MemberId(6) << data.target_latency()
-        << eprosima::fastcdr::MemberId(7) << data.extra_data()
-        << eprosima::fastcdr::MemberId(8) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.model_properties_path(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.model_properties(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.input_batch(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.target_latency(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.model_path()
+                << eprosima::fastcdr::MemberId(1) << data.model()
+                << eprosima::fastcdr::MemberId(2) << data.raw_model()
+                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+                << eprosima::fastcdr::MemberId(4) << data.model_properties()
+                << eprosima::fastcdr::MemberId(5) << data.input_batch()
+                << eprosima::fastcdr::MemberId(6) << data.target_latency()
+                << eprosima::fastcdr::MemberId(7) << data.extra_data()
+                << eprosima::fastcdr::MemberId(8) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.model_path();
-                                            break;
+                    case 0:
+                        dcdr >> data.model_path();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.model();
-                                            break;
+                    case 1:
+                        dcdr >> data.model();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.raw_model();
-                                            break;
+                    case 2:
+                        dcdr >> data.raw_model();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.model_properties_path();
-                                            break;
+                    case 3:
+                        dcdr >> data.model_properties_path();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.model_properties();
-                                            break;
+                    case 4:
+                        dcdr >> data.model_properties();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.input_batch();
-                                            break;
+                    case 5:
+                        dcdr >> data.input_batch();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.target_latency();
-                                            break;
+                    case 6:
+                        dcdr >> data.target_latency();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 7:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 8:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1004,130 +1019,132 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWResourceImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWResourceImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.hw_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.power_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.memory_footprint_of_ml_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.max_hw_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.hw_description(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.power_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.latency(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.hw_description()
-        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.latency()
-        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-        << eprosima::fastcdr::MemberId(5) << data.extra_data()
-        << eprosima::fastcdr::MemberId(6) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.memory_footprint_of_ml_model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWResourceImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.max_hw_memory_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.hw_description()
+                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.latency()
+                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+                << eprosima::fastcdr::MemberId(5) << data.extra_data()
+                << eprosima::fastcdr::MemberId(6) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWResourceImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.hw_description();
-                                            break;
+                    case 0:
+                        dcdr >> data.hw_description();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.power_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.power_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.latency();
-                                            break;
+                    case 2:
+                        dcdr >> data.latency();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.memory_footprint_of_ml_model();
-                                            break;
+                    case 3:
+                        dcdr >> data.memory_footprint_of_ml_model();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.max_hw_memory_footprint();
-                                            break;
+                    case 4:
+                        dcdr >> data.max_hw_memory_footprint();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 5:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 6:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1135,114 +1152,116 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const CO2FootprintImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const CO2FootprintImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.energy_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.carbon_intensity(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.carbon_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.energy_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.carbon_intensity(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-        << eprosima::fastcdr::MemberId(3) << data.extra_data()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        CO2FootprintImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+                << eprosima::fastcdr::MemberId(3) << data.extra_data()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                CO2FootprintImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.carbon_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.carbon_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.energy_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.energy_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.carbon_intensity();
-                                            break;
+                    case 2:
+                        dcdr >> data.carbon_intensity();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 3:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1250,26 +1269,24 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
-
-
-} // namespace fastcdr
+    } // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.cxx
@@ -128,8 +128,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,7 +184,8 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -309,8 +310,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -365,7 +366,8 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -392,8 +394,6 @@ void NodeStatusImplPubSubType::register_type_object_representation()
 {
     register_NodeStatusImpl_type_identifier(type_identifiers_);
 }
-
-
 
 NodeControlImplPubSubType::NodeControlImplPubSubType()
 {
@@ -492,8 +492,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,7 +548,8 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -673,8 +674,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -729,7 +730,8 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -854,8 +856,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -910,7 +912,8 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -1035,8 +1038,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1091,7 +1094,8 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1216,8 +1220,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1272,7 +1276,8 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1397,8 +1402,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1453,7 +1458,8 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1578,8 +1584,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1634,7 +1640,8 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1759,8 +1766,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1815,7 +1822,8 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1842,7 +1850,6 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
-
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.cxx
@@ -128,8 +128,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,8 +184,7 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -310,8 +309,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -366,8 +365,7 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -394,6 +392,8 @@ void NodeStatusImplPubSubType::register_type_object_representation()
 {
     register_NodeStatusImpl_type_identifier(type_identifiers_);
 }
+
+
 
 NodeControlImplPubSubType::NodeControlImplPubSubType()
 {
@@ -492,8 +492,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,8 +548,7 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -674,8 +673,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -730,8 +729,7 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -856,8 +854,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -912,8 +910,7 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -1038,8 +1035,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1094,8 +1091,7 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1220,8 +1216,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1276,8 +1272,7 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1402,8 +1397,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1458,8 +1453,7 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1584,8 +1578,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1640,8 +1634,7 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1766,8 +1759,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1822,8 +1815,7 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1850,6 +1842,7 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
+
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
@@ -43,7 +43,8 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -53,151 +54,204 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
+                        ann_custom_Status,
+                        type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
+                        detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
+                            member_ann_builtin_NODE_ERROR,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
+                            member_ann_builtin_NODE_IDLE,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
+                            member_ann_builtin_NODE_RUNNING,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
+                            flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
-                literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_Status, header_Status,
+            literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
+                type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "Status already registered in TypeObjectRegistry for a different type.");
+                    "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_TaskStatus_type_identifier(
+}
+
+void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus =
+                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
+                        ann_custom_TaskStatus,
+                        type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
+            common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
+                            member_ann_builtin_TASK_WAITING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
+                            member_ann_builtin_TASK_ERROR,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
+                            member_ann_builtin_TASK_RUNNING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
+                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
-                literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_TaskStatus, header_TaskStatus,
+            literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
+                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_ErrorCode_type_identifier(
+}
+
+void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -207,55 +261,72 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
+                        ann_custom_ErrorCode,
+                        type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
+                        detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR =
+                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
+                            member_ann_builtin_NO_ERROR,
+                            ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
+                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
-                literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_ErrorCode, header_ErrorCode,
+            literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
+                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
+                        ann_custom_TaskIdImpl,
+                        type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -263,7 +334,8 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -272,28 +344,37 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
+                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_problem_id,
+                                                              common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
+                            member_ann_builtin_problem_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
+                            detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -302,32 +383,44 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
+                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_iteration_id,
+                                                                common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
+                            member_ann_builtin_iteration_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
+                common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
+                        header_TaskIdImpl,
+                        member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
+                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -335,16 +428,19 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -352,91 +448,119 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-            ::register_Status_type_identifier(type_ids_node_status);
+                ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
+                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_node_status,
+                                                               common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
+                            member_ann_builtin_node_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
+                            detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-            ::register_TaskStatus_type_identifier(type_ids_task_status);
+                ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
+                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_task_status,
+                                                               common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
+                            member_ann_builtin_task_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
+                            detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-            ::register_ErrorCode_type_identifier(type_ids_error_code);
+                ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
+                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_error_code,
+                                                              common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
+                            member_ann_builtin_error_code,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
+                            detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -449,32 +573,41 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_error_description,
+                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_error_description,
+                                                                 common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
+                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
+                common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -487,18 +620,23 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
+                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_node_name,
+                                                             common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -509,34 +647,46 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
+                    hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
+                                min_node_name,
+                                max_node_name,
+                                hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
+                            member_ann_builtin_node_name,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
+                            detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -550,33 +700,44 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
+                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -586,74 +747,101 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
+                        ann_custom_CmdNode,
+                        type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
+                        detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
+                            member_ann_builtin_NO_CMD_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
+                            member_ann_builtin_START_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
+                            member_ann_builtin_STOP_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
+                            member_ann_builtin_RESET_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
-                literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdNode, header_CmdNode,
+            literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
+                type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdNode already registered in TypeObjectRegistry for a different type.");
+                    "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_CmdTask_type_identifier(
+}
+
+void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -663,149 +851,197 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
+                        ann_custom_CmdTask,
+                        type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
+                        detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
+                            member_ann_builtin_NO_CMD_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
+                            member_ann_builtin_STOP_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
+                            member_ann_builtin_RESET_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
+                            member_ann_builtin_PREEMPT_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
-                literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdTask, header_CmdTask,
+            literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
+                type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdTask already registered in TypeObjectRegistry for a different type.");
+                    "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl =
+                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-            ::register_CmdNode_type_identifier(type_ids_cmd_node);
+                ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
+                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_node,
+                                                            common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
+                            member_ann_builtin_cmd_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
+                            detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-            ::register_CmdTask_type_identifier(type_ids_cmd_task);
+                ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
+                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_task,
+                                                            common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
+                            member_ann_builtin_cmd_task,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
+                            detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -818,32 +1054,41 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
+                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_target_node,
+                                                               common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
+                            member_ann_builtin_target_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
+                            detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -856,18 +1101,23 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
+                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_source_node,
+                                                               common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -878,34 +1128,44 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
+                    hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
+                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
+                            member_ann_builtin_source_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
+                            detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -919,27 +1179,37 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
+                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -947,16 +1217,19 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -964,7 +1237,8 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -977,32 +1251,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
+                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_modality,
+                                                            common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
+                            member_ann_builtin_modality,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
+                            detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1015,32 +1298,42 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
+                                                                     member_id_problem_short_description,
+                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                         type_ids_problem_short_description,
+                                                                         common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
+                name_problem_short_description, member_ann_builtin_problem_short_description,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
+                common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1053,38 +1346,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_problem_definition,
+                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_problem_definition,
+                                                                  common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
+                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
+                common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1097,12 +1400,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_inputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1114,24 +1420,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
+                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                          type_ids_inputs,
+                                                          common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1140,21 +1456,26 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
+                            member_ann_builtin_inputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
+                            detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1167,12 +1488,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_outputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1184,24 +1508,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
+                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_outputs,
+                                                           common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1210,15 +1544,19 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
+                            member_ann_builtin_outputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
+                            detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1227,28 +1565,36 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_minimum_samples,
+                                                               common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1257,28 +1603,36 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_maximum_samples,
+                                                               common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1287,28 +1641,42 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
+                                                                            member_id_optimize_carbon_footprint_manual,
+                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                type_ids_optimize_carbon_footprint_manual,
+                                                                                common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
+                            member_ann_builtin_optimize_carbon_footprint_manual,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
+                            detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1317,28 +1685,37 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_previous_iteration,
+                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_previous_iteration,
+                                                                  common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
+                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
+                common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1347,28 +1724,40 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
+                                                                          member_id_optimize_carbon_footprint_auto,
+                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                              type_ids_optimize_carbon_footprint_auto,
+                                                                              common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
+                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
+                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1377,28 +1766,38 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                    member_id_desired_carbon_footprint,
+                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                        type_ids_desired_carbon_footprint,
+                                                                        common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1411,32 +1810,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
+                                                                  member_id_geo_location_continent,
+                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                      type_ids_geo_location_continent,
+                                                                      common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1449,38 +1857,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
+                                                               member_id_geo_location_region,
+                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                   type_ids_geo_location_region,
+                                                                   common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1490,7 +1908,9 @@ void register_UserInputImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1502,52 +1922,70 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1561,27 +1999,37 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
+                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -1589,30 +2037,37 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
+            type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -1625,12 +2080,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_keywords,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1642,47 +2100,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
+                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_keywords,
+                                                            common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
+                            member_ann_builtin_keywords,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
+                            detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -1695,12 +2169,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_ml_model_metadata,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1712,47 +2189,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_ml_model_metadata,
+                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_ml_model_metadata,
+                                                                 common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
+                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
+                common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1762,7 +2255,9 @@ void register_MLModelMetadataImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1774,52 +2269,70 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1833,27 +2346,37 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
+                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -1861,30 +2384,37 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
+            type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -1897,12 +2427,15 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_app_requirements,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1914,47 +2447,62 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_app_requirements,
+                                                                common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
+                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
+                common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1964,7 +2512,9 @@ void register_AppRequirementsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1976,52 +2526,70 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2035,27 +2603,37 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
+                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2063,24 +2641,30 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
+            type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2089,34 +2673,44 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                member_id_max_memory_footprint,
+                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                    type_ids_max_memory_footprint,
+                                                                    common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_hardware_required;
             ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hardware_required =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
             {
                 return_code_hardware_required =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_hardware_required);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
@@ -2129,12 +2723,15 @@ void register_HWConstraintsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_hardware_required))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_hardware_required,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2146,47 +2743,63 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_hardware_required = 0x00000001;
             bool common_hardware_required_ec {false};
-            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_hardware_required,
+                                                             member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_hardware_required,
+                                                                 common_hardware_required_ec))};
             if (!common_hardware_required_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure hardware_required member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hardware_required = "hardware_required";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(
+                name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(
+                common_hardware_required, detail_hardware_required);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2196,7 +2809,9 @@ void register_HWConstraintsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2208,52 +2823,70 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2267,27 +2900,37 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
+                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2295,16 +2938,19 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2312,7 +2958,8 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2325,32 +2972,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
+                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_model_path,
+                                                              common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
+                            member_ann_builtin_model_path,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
+                            detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2363,15 +3019,19 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
+                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                         type_ids_model,
+                                                         common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2380,21 +3040,26 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
+                            member_ann_builtin_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model =
+                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2404,7 +3069,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_raw_model,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2416,41 +3083,55 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
+                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_raw_model,
+                                                             common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
+                            member_ann_builtin_raw_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
+                            detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -2463,32 +3144,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
+                                                                 member_id_model_properties_path,
+                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                     type_ids_model_properties_path,
+                                                                     common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -2501,38 +3191,47 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_model_properties,
+                                                                common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -2545,12 +3244,15 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_input_batch,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2562,41 +3264,56 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
+                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_input_batch,
+                                                               common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
+                            member_ann_builtin_input_batch,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
+                            detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -2605,34 +3322,43 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_target_latency,
+                                                              common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
+                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
+                common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2642,7 +3368,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2654,52 +3382,70 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2713,27 +3459,37 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
+                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -2741,16 +3497,19 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -2758,7 +3517,8 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -2771,32 +3531,40 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_hw_description,
+                                                              common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
+                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
+                common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -2805,28 +3573,37 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_power_consumption,
+                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_power_consumption,
+                                                                 common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -2835,11 +3612,15 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
+                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_latency,
+                                                           common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -2848,15 +3629,19 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
+                            member_ann_builtin_latency,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
+                            detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -2865,28 +3650,38 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
+                                                                        member_id_memory_footprint_of_ml_model,
+                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                            type_ids_memory_footprint_of_ml_model,
+                                                                            common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
+                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
+                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -2895,34 +3690,45 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                   member_id_max_hw_memory_footprint,
+                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                       type_ids_max_hw_memory_footprint,
+                                                                       common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2932,7 +3738,9 @@ void register_HWResourceImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2944,52 +3752,70 @@ void register_HWResourceImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3003,27 +3829,37 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
+                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3031,24 +3867,29 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3057,28 +3898,36 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_footprint,
+                                                                common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3087,28 +3936,37 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_energy_consumption,
+                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_energy_consumption,
+                                                                  common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3117,34 +3975,43 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_intensity,
+                                                                common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3154,7 +4021,9 @@ void register_CO2FootprintImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3166,52 +4035,70 @@ void register_CO2FootprintImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3225,25 +4112,33 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
+                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-

--- a/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
@@ -43,8 +43,7 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -54,204 +53,151 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
-                        ann_custom_Status,
-                        type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
-                        detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
-                            member_ann_builtin_NODE_ERROR,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
-                            member_ann_builtin_NODE_IDLE,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
-                            member_ann_builtin_NODE_RUNNING,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
-                            flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_Status, header_Status,
-            literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
+                literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
-                type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "Status already registered in TypeObjectRegistry for a different type.");
+                "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_TaskStatus_type_identifier(
+}void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus =
-                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
-                        ann_custom_TaskStatus,
-                        type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
-            common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
-                            member_ann_builtin_TASK_WAITING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
-                            member_ann_builtin_TASK_ERROR,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
-                            member_ann_builtin_TASK_RUNNING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
-                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_TaskStatus, header_TaskStatus,
-            literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
+                literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
-                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_ErrorCode_type_identifier(
+}void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -261,72 +207,55 @@ void register_ErrorCode_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
-                        ann_custom_ErrorCode,
-                        type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
-                        detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR =
-                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
-                            member_ann_builtin_NO_ERROR,
-                            ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
-                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_ErrorCode, header_ErrorCode,
-            literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
+                literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
-                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
-                        ann_custom_TaskIdImpl,
-                        type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -334,8 +263,7 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -344,37 +272,28 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
-                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_problem_id,
-                                                              common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
-                            member_ann_builtin_problem_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
-                            detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -383,44 +302,32 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
-                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_iteration_id,
-                                                                common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
-                            member_ann_builtin_iteration_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
-                common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
-                        header_TaskIdImpl,
-                        member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
-                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -428,19 +335,16 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -448,119 +352,91 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-                ::register_Status_type_identifier(type_ids_node_status);
+            ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
-                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_node_status,
-                                                               common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
-                            member_ann_builtin_node_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
-                            detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-                ::register_TaskStatus_type_identifier(type_ids_task_status);
+            ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
-                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_task_status,
-                                                               common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
-                            member_ann_builtin_task_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
-                            detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-                ::register_ErrorCode_type_identifier(type_ids_error_code);
+            ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
-                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_error_code,
-                                                              common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
-                            member_ann_builtin_error_code,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
-                            detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -573,41 +449,32 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_error_description,
-                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_error_description,
-                                                                 common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
-                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
-                common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -620,23 +487,18 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
-                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_node_name,
-                                                             common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -647,46 +509,34 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
-                    hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
-                                min_node_name,
-                                max_node_name,
-                                hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
-                            member_ann_builtin_node_name,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
-                            detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -700,44 +550,33 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
-                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -747,101 +586,74 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
-                        ann_custom_CmdNode,
-                        type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
-                        detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
-                            member_ann_builtin_NO_CMD_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
-                            member_ann_builtin_START_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
-                            member_ann_builtin_STOP_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
-                            member_ann_builtin_RESET_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdNode, header_CmdNode,
-            literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
+                literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
-                type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdNode already registered in TypeObjectRegistry for a different type.");
+                "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_CmdTask_type_identifier(
+}void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -851,197 +663,149 @@ void register_CmdTask_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
-                        ann_custom_CmdTask,
-                        type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
-                        detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
-                            member_ann_builtin_NO_CMD_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
-                            member_ann_builtin_STOP_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
-                            member_ann_builtin_RESET_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
-                            member_ann_builtin_PREEMPT_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdTask, header_CmdTask,
-            literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
+                literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
-                type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdTask already registered in TypeObjectRegistry for a different type.");
+                "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl =
-                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-                ::register_CmdNode_type_identifier(type_ids_cmd_node);
+            ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
-                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_node,
-                                                            common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
-                            member_ann_builtin_cmd_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
-                            detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-                ::register_CmdTask_type_identifier(type_ids_cmd_task);
+            ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
-                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_task,
-                                                            common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
-                            member_ann_builtin_cmd_task,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
-                            detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -1054,41 +818,32 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
-                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_target_node,
-                                                               common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
-                            member_ann_builtin_target_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
-                            detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -1101,23 +856,18 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
-                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_source_node,
-                                                               common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -1128,44 +878,34 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
-                    hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
-                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
-                            member_ann_builtin_source_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
-                            detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1179,37 +919,27 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
-                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -1217,19 +947,16 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -1237,8 +964,7 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -1251,41 +977,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
-                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_modality,
-                                                            common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
-                            member_ann_builtin_modality,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
-                            detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1298,42 +1015,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
-                                                                     member_id_problem_short_description,
-                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                         type_ids_problem_short_description,
-                                                                         common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
-                name_problem_short_description, member_ann_builtin_problem_short_description,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
-                common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1346,48 +1053,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_problem_definition,
-                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_problem_definition,
-                                                                  common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
-                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
-                common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1400,15 +1097,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_inputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1420,34 +1114,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
-                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                          type_ids_inputs,
-                                                          common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1456,26 +1140,21 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
-                            member_ann_builtin_inputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
-                            detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1488,15 +1167,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_outputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1508,34 +1184,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
-                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_outputs,
-                                                           common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1544,19 +1210,15 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
-                            member_ann_builtin_outputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
-                            detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1565,36 +1227,28 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_minimum_samples,
-                                                               common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1603,36 +1257,28 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_maximum_samples,
-                                                               common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1641,42 +1287,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
-                                                                            member_id_optimize_carbon_footprint_manual,
-                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                type_ids_optimize_carbon_footprint_manual,
-                                                                                common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
-                            member_ann_builtin_optimize_carbon_footprint_manual,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
-                            detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1685,37 +1317,28 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_previous_iteration,
-                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_previous_iteration,
-                                                                  common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
-                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
-                common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1724,40 +1347,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
-                                                                          member_id_optimize_carbon_footprint_auto,
-                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                              type_ids_optimize_carbon_footprint_auto,
-                                                                              common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
-                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
-                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1766,38 +1377,28 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                    member_id_desired_carbon_footprint,
-                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                        type_ids_desired_carbon_footprint,
-                                                                        common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1810,41 +1411,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
-                                                                  member_id_geo_location_continent,
-                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                      type_ids_geo_location_continent,
-                                                                      common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1857,48 +1449,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
-                                                               member_id_geo_location_region,
-                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                   type_ids_geo_location_region,
-                                                                   common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1908,9 +1490,7 @@ void register_UserInputImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1922,70 +1502,52 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1999,37 +1561,27 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
-                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -2037,37 +1589,30 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
-            type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -2080,15 +1625,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_keywords,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2100,63 +1642,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
-                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_keywords,
-                                                            common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
-                            member_ann_builtin_keywords,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
-                            detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -2169,15 +1695,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_ml_model_metadata,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2189,63 +1712,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_ml_model_metadata,
-                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_ml_model_metadata,
-                                                                 common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
-                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
-                common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2255,9 +1762,7 @@ void register_MLModelMetadataImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2269,70 +1774,52 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2346,37 +1833,27 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
-                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -2384,37 +1861,30 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
-            type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -2427,15 +1897,12 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_app_requirements,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2447,62 +1914,47 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_app_requirements,
-                                                                common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
-                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
-                common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2512,9 +1964,7 @@ void register_AppRequirementsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2526,70 +1976,52 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2603,37 +2035,27 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
-                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2641,30 +2063,24 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
-            type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2673,44 +2089,104 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                member_id_max_memory_footprint,
-                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                    type_ids_max_memory_footprint,
-                                                                    common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
+        }
+        {
+            TypeIdentifierPair type_ids_hardware_required;
+            ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_hardware_required =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
+            {
+                return_code_hardware_required =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "anonymous_string_unbounded", type_ids_hardware_required);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
+                {
+                    {
+                        SBound bound = 0;
+                        StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                                TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                                "anonymous_string_unbounded", type_ids_hardware_required))
+                        {
+                            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                        }
+                    }
+                }
+                bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_COMPLETE;
+                if (TK_NONE == type_ids_hardware_required.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                {
+                    SBound bound = 0;
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_hardware_required = 0x00000001;
+            bool common_hardware_required_ec {false};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
+            if (!common_hardware_required_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_hardware_required = "hardware_required";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
+            ann_custom_HWConstraintsImpl.reset();
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
+            TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2720,9 +2196,7 @@ void register_HWConstraintsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2734,70 +2208,52 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
-            MemberId member_id_extra_data = 0x00000001;
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
-            MemberId member_id_task_id = 0x00000002;
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2811,37 +2267,27 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
-                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2849,19 +2295,16 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2869,8 +2312,7 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2883,41 +2325,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
-                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_model_path,
-                                                              common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
-                            member_ann_builtin_model_path,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
-                            detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2930,19 +2363,15 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
-                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                         type_ids_model,
-                                                         common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2951,26 +2380,21 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
-                            member_ann_builtin_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model =
-                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2980,9 +2404,7 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_raw_model,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2994,55 +2416,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
-                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_raw_model,
-                                                             common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
-                            member_ann_builtin_raw_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
-                            detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -3055,41 +2463,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
-                                                                 member_id_model_properties_path,
-                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                     type_ids_model_properties_path,
-                                                                     common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -3102,47 +2501,38 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_model_properties,
-                                                                common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -3155,15 +2545,12 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_input_batch,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3175,56 +2562,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
-                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_input_batch,
-                                                               common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
-                            member_ann_builtin_input_batch,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
-                            detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -3233,43 +2605,34 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_target_latency,
-                                                              common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
-                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
-                common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3279,9 +2642,7 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3293,70 +2654,52 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3370,37 +2713,27 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
-                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -3408,19 +2741,16 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -3428,8 +2758,7 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -3442,40 +2771,32 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_hw_description,
-                                                              common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
-                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
-                common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -3484,37 +2805,28 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_power_consumption,
-                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_power_consumption,
-                                                                 common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -3523,15 +2835,11 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
-                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_latency,
-                                                           common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -3540,19 +2848,15 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
-                            member_ann_builtin_latency,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
-                            detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -3561,38 +2865,28 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
-                                                                        member_id_memory_footprint_of_ml_model,
-                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                            type_ids_memory_footprint_of_ml_model,
-                                                                            common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
-                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
-                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -3601,45 +2895,34 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                   member_id_max_hw_memory_footprint,
-                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                       type_ids_max_hw_memory_footprint,
-                                                                       common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3649,9 +2932,7 @@ void register_HWResourceImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3663,70 +2944,52 @@ void register_HWResourceImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3740,37 +3003,27 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
-                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3778,29 +3031,24 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3809,36 +3057,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_footprint,
-                                                                common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3847,37 +3087,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_energy_consumption,
-                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_energy_consumption,
-                                                                  common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3886,43 +3117,34 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_intensity,
-                                                                common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3932,9 +3154,7 @@ void register_CO2FootprintImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3946,70 +3166,52 @@ void register_CO2FootprintImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -4023,33 +3225,25 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
-                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+

--- a/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
@@ -43,8 +43,7 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -54,204 +53,151 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
-                        ann_custom_Status,
-                        type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
-                        detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
-                            member_ann_builtin_NODE_ERROR,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
-                            member_ann_builtin_NODE_IDLE,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
-                            member_ann_builtin_NODE_RUNNING,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
-                            flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_Status, header_Status,
-            literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
+                literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
-                type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "Status already registered in TypeObjectRegistry for a different type.");
+                "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_TaskStatus_type_identifier(
+}void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus =
-                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
-                        ann_custom_TaskStatus,
-                        type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
-            common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
-                            member_ann_builtin_TASK_WAITING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
-                            member_ann_builtin_TASK_ERROR,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
-                            member_ann_builtin_TASK_RUNNING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
-                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_TaskStatus, header_TaskStatus,
-            literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
+                literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
-                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_ErrorCode_type_identifier(
+}void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -261,72 +207,55 @@ void register_ErrorCode_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
-                        ann_custom_ErrorCode,
-                        type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
-                        detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR =
-                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
-                            member_ann_builtin_NO_ERROR,
-                            ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
-                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_ErrorCode, header_ErrorCode,
-            literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
+                literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
-                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
-                        ann_custom_TaskIdImpl,
-                        type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -334,8 +263,7 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -344,37 +272,28 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
-                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_problem_id,
-                                                              common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
-                            member_ann_builtin_problem_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
-                            detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -383,44 +302,32 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
-                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_iteration_id,
-                                                                common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
-                            member_ann_builtin_iteration_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
-                common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
-                        header_TaskIdImpl,
-                        member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
-                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -428,19 +335,16 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -448,119 +352,91 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-                ::register_Status_type_identifier(type_ids_node_status);
+            ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
-                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_node_status,
-                                                               common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
-                            member_ann_builtin_node_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
-                            detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-                ::register_TaskStatus_type_identifier(type_ids_task_status);
+            ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
-                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_task_status,
-                                                               common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
-                            member_ann_builtin_task_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
-                            detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-                ::register_ErrorCode_type_identifier(type_ids_error_code);
+            ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
-                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_error_code,
-                                                              common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
-                            member_ann_builtin_error_code,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
-                            detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -573,41 +449,32 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_error_description,
-                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_error_description,
-                                                                 common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
-                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
-                common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -620,23 +487,18 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
-                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_node_name,
-                                                             common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -647,46 +509,34 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
-                    hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
-                                min_node_name,
-                                max_node_name,
-                                hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
-                            member_ann_builtin_node_name,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
-                            detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -700,44 +550,33 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
-                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -747,101 +586,74 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
-                        ann_custom_CmdNode,
-                        type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
-                        detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
-                            member_ann_builtin_NO_CMD_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
-                            member_ann_builtin_START_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
-                            member_ann_builtin_STOP_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
-                            member_ann_builtin_RESET_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdNode, header_CmdNode,
-            literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
+                literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
-                type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdNode already registered in TypeObjectRegistry for a different type.");
+                "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_CmdTask_type_identifier(
+}void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -851,197 +663,149 @@ void register_CmdTask_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
-                        ann_custom_CmdTask,
-                        type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
-                        detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
-                            member_ann_builtin_NO_CMD_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
-                            member_ann_builtin_STOP_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
-                            member_ann_builtin_RESET_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
-                            member_ann_builtin_PREEMPT_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdTask, header_CmdTask,
-            literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
+                literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
-                type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdTask already registered in TypeObjectRegistry for a different type.");
+                "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl =
-                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-                ::register_CmdNode_type_identifier(type_ids_cmd_node);
+            ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
-                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_node,
-                                                            common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
-                            member_ann_builtin_cmd_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
-                            detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-                ::register_CmdTask_type_identifier(type_ids_cmd_task);
+            ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
-                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_task,
-                                                            common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
-                            member_ann_builtin_cmd_task,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
-                            detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -1054,41 +818,32 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
-                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_target_node,
-                                                               common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
-                            member_ann_builtin_target_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
-                            detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -1101,23 +856,18 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
-                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_source_node,
-                                                               common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -1128,44 +878,34 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
-                    hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
-                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
-                            member_ann_builtin_source_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
-                            detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1179,37 +919,27 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
-                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -1217,19 +947,16 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -1237,8 +964,7 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -1251,41 +977,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
-                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_modality,
-                                                            common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
-                            member_ann_builtin_modality,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
-                            detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1298,42 +1015,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
-                                                                     member_id_problem_short_description,
-                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                         type_ids_problem_short_description,
-                                                                         common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
-                name_problem_short_description, member_ann_builtin_problem_short_description,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
-                common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1346,48 +1053,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_problem_definition,
-                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_problem_definition,
-                                                                  common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
-                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
-                common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1400,15 +1097,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_inputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1420,34 +1114,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
-                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                          type_ids_inputs,
-                                                          common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1456,26 +1140,21 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
-                            member_ann_builtin_inputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
-                            detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1488,15 +1167,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_outputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1508,34 +1184,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
-                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_outputs,
-                                                           common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1544,19 +1210,15 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
-                            member_ann_builtin_outputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
-                            detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1565,36 +1227,28 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_minimum_samples,
-                                                               common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1603,36 +1257,28 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_maximum_samples,
-                                                               common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1641,42 +1287,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
-                                                                            member_id_optimize_carbon_footprint_manual,
-                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                type_ids_optimize_carbon_footprint_manual,
-                                                                                common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
-                            member_ann_builtin_optimize_carbon_footprint_manual,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
-                            detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1685,37 +1317,28 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_previous_iteration,
-                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_previous_iteration,
-                                                                  common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
-                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
-                common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1724,40 +1347,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
-                                                                          member_id_optimize_carbon_footprint_auto,
-                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                              type_ids_optimize_carbon_footprint_auto,
-                                                                              common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
-                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
-                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1766,38 +1377,28 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                    member_id_desired_carbon_footprint,
-                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                        type_ids_desired_carbon_footprint,
-                                                                        common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1810,41 +1411,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
-                                                                  member_id_geo_location_continent,
-                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                      type_ids_geo_location_continent,
-                                                                      common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1857,48 +1449,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
-                                                               member_id_geo_location_region,
-                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                   type_ids_geo_location_region,
-                                                                   common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1907,85 +1489,65 @@ void register_UserInputImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1999,37 +1561,27 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
-                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -2037,37 +1589,30 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
-            type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -2080,15 +1625,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_keywords,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2100,63 +1642,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
-                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_keywords,
-                                                            common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
-                            member_ann_builtin_keywords,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
-                            detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -2169,15 +1695,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_ml_model_metadata,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2189,63 +1712,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_ml_model_metadata,
-                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_ml_model_metadata,
-                                                                 common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
-                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
-                common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2254,85 +1761,65 @@ void register_MLModelMetadataImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2346,37 +1833,27 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
-                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -2384,37 +1861,30 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
-            type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -2427,15 +1897,12 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_app_requirements,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2447,62 +1914,47 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_app_requirements,
-                                                                common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
-                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
-                common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2511,85 +1963,65 @@ void register_AppRequirementsImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2603,37 +2035,27 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
-                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2641,30 +2063,24 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
-            type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2673,44 +2089,34 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                member_id_max_memory_footprint,
-                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                    type_ids_max_memory_footprint,
-                                                                    common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2719,85 +2125,65 @@ void register_HWConstraintsImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2811,37 +2197,27 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
-                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2849,19 +2225,16 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2869,8 +2242,7 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2883,41 +2255,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
-                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_model_path,
-                                                              common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
-                            member_ann_builtin_model_path,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
-                            detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2930,19 +2293,15 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
-                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                         type_ids_model,
-                                                         common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2951,26 +2310,21 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
-                            member_ann_builtin_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model =
-                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_raw_model);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2979,70 +2333,54 @@ void register_MLModelImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_raw_model,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_raw_model.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
-                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_raw_model,
-                                                             common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
-                            member_ann_builtin_raw_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
-                            detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -3055,41 +2393,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
-                                                                 member_id_model_properties_path,
-                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                     type_ids_model_properties_path,
-                                                                     common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -3102,47 +2431,38 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_model_properties,
-                                                                common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -3155,15 +2475,12 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_input_batch,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3175,56 +2492,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
-                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_input_batch,
-                                                               common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
-                            member_ann_builtin_input_batch,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
-                            detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -3233,43 +2535,34 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_target_latency,
-                                                              common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
-                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
-                common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3278,85 +2571,65 @@ void register_MLModelImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3370,37 +2643,27 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
-                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -3408,19 +2671,16 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -3428,8 +2688,7 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -3442,40 +2701,32 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_hw_description,
-                                                              common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
-                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
-                common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -3484,37 +2735,28 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_power_consumption,
-                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_power_consumption,
-                                                                 common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -3523,15 +2765,11 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
-                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_latency,
-                                                           common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -3540,19 +2778,15 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
-                            member_ann_builtin_latency,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
-                            detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -3561,38 +2795,28 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
-                                                                        member_id_memory_footprint_of_ml_model,
-                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                            type_ids_memory_footprint_of_ml_model,
-                                                                            common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
-                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
-                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -3601,45 +2825,34 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                   member_id_max_hw_memory_footprint,
-                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                       type_ids_max_hw_memory_footprint,
-                                                                       common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3648,85 +2861,65 @@ void register_HWResourceImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3740,37 +2933,27 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
-                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3778,29 +2961,24 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3809,36 +2987,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_footprint,
-                                                                common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3847,37 +3017,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_energy_consumption,
-                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_energy_consumption,
-                                                                  common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3886,43 +3047,34 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_intensity,
-                                                                common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3931,85 +3083,65 @@ void register_CO2FootprintImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -4023,33 +3155,25 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
-                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+

--- a/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
@@ -43,7 +43,8 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -53,151 +54,204 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
+                        ann_custom_Status,
+                        type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
+                        detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
+                            member_ann_builtin_NODE_ERROR,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
+                            member_ann_builtin_NODE_IDLE,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
+                            member_ann_builtin_NODE_RUNNING,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
+                            flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
-                literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_Status, header_Status,
+            literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
+                type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "Status already registered in TypeObjectRegistry for a different type.");
+                    "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_TaskStatus_type_identifier(
+}
+
+void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus =
+                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
+                        ann_custom_TaskStatus,
+                        type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
+            common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
+                            member_ann_builtin_TASK_WAITING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
+                            member_ann_builtin_TASK_ERROR,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
+                            member_ann_builtin_TASK_RUNNING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
+                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
-                literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_TaskStatus, header_TaskStatus,
+            literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
+                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_ErrorCode_type_identifier(
+}
+
+void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -207,55 +261,72 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
+                        ann_custom_ErrorCode,
+                        type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
+                        detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR =
+                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
+                            member_ann_builtin_NO_ERROR,
+                            ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
+                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
-                literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_ErrorCode, header_ErrorCode,
+            literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
+                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
+                        ann_custom_TaskIdImpl,
+                        type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -263,7 +334,8 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -272,28 +344,37 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
+                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_problem_id,
+                                                              common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
+                            member_ann_builtin_problem_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
+                            detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -302,32 +383,44 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
+                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_iteration_id,
+                                                                common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
+                            member_ann_builtin_iteration_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
+                common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
+                        header_TaskIdImpl,
+                        member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
+                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -335,16 +428,19 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -352,91 +448,119 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-            ::register_Status_type_identifier(type_ids_node_status);
+                ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
+                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_node_status,
+                                                               common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
+                            member_ann_builtin_node_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
+                            detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-            ::register_TaskStatus_type_identifier(type_ids_task_status);
+                ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
+                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_task_status,
+                                                               common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
+                            member_ann_builtin_task_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
+                            detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-            ::register_ErrorCode_type_identifier(type_ids_error_code);
+                ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
+                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_error_code,
+                                                              common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
+                            member_ann_builtin_error_code,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
+                            detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -449,32 +573,41 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_error_description,
+                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_error_description,
+                                                                 common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
+                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
+                common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -487,18 +620,23 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
+                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_node_name,
+                                                             common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -509,34 +647,46 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
+                    hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
+                                min_node_name,
+                                max_node_name,
+                                hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
+                            member_ann_builtin_node_name,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
+                            detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -550,33 +700,44 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
+                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -586,74 +747,101 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
+                        ann_custom_CmdNode,
+                        type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
+                        detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
+                            member_ann_builtin_NO_CMD_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
+                            member_ann_builtin_START_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
+                            member_ann_builtin_STOP_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
+                            member_ann_builtin_RESET_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
-                literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdNode, header_CmdNode,
+            literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
+                type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdNode already registered in TypeObjectRegistry for a different type.");
+                    "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_CmdTask_type_identifier(
+}
+
+void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -663,149 +851,197 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
+                        ann_custom_CmdTask,
+                        type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
+                        detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
+                            member_ann_builtin_NO_CMD_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
+                            member_ann_builtin_STOP_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
+                            member_ann_builtin_RESET_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
+                            member_ann_builtin_PREEMPT_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
-                literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdTask, header_CmdTask,
+            literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
+                type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdTask already registered in TypeObjectRegistry for a different type.");
+                    "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl =
+                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-            ::register_CmdNode_type_identifier(type_ids_cmd_node);
+                ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
+                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_node,
+                                                            common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
+                            member_ann_builtin_cmd_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
+                            detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-            ::register_CmdTask_type_identifier(type_ids_cmd_task);
+                ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
+                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_task,
+                                                            common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
+                            member_ann_builtin_cmd_task,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
+                            detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -818,32 +1054,41 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
+                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_target_node,
+                                                               common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
+                            member_ann_builtin_target_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
+                            detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -856,18 +1101,23 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
+                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_source_node,
+                                                               common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -878,34 +1128,44 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
+                    hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
+                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
+                            member_ann_builtin_source_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
+                            detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -919,27 +1179,37 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
+                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -947,16 +1217,19 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -964,7 +1237,8 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -977,32 +1251,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
+                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_modality,
+                                                            common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
+                            member_ann_builtin_modality,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
+                            detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1015,32 +1298,42 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
+                                                                     member_id_problem_short_description,
+                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                         type_ids_problem_short_description,
+                                                                         common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
+                name_problem_short_description, member_ann_builtin_problem_short_description,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
+                common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1053,38 +1346,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_problem_definition,
+                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_problem_definition,
+                                                                  common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
+                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
+                common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1097,12 +1400,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_inputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1114,24 +1420,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
+                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                          type_ids_inputs,
+                                                          common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1140,21 +1456,26 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
+                            member_ann_builtin_inputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
+                            detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1167,12 +1488,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_outputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1184,24 +1508,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
+                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_outputs,
+                                                           common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1210,15 +1544,19 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
+                            member_ann_builtin_outputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
+                            detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1227,28 +1565,36 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_minimum_samples,
+                                                               common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1257,28 +1603,36 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_maximum_samples,
+                                                               common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1287,28 +1641,42 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
+                                                                            member_id_optimize_carbon_footprint_manual,
+                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                type_ids_optimize_carbon_footprint_manual,
+                                                                                common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
+                            member_ann_builtin_optimize_carbon_footprint_manual,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
+                            detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1317,28 +1685,37 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_previous_iteration,
+                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_previous_iteration,
+                                                                  common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
+                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
+                common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1347,28 +1724,40 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
+                                                                          member_id_optimize_carbon_footprint_auto,
+                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                              type_ids_optimize_carbon_footprint_auto,
+                                                                              common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
+                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
+                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1377,28 +1766,38 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                    member_id_desired_carbon_footprint,
+                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                        type_ids_desired_carbon_footprint,
+                                                                        common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1411,32 +1810,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
+                                                                  member_id_geo_location_continent,
+                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                      type_ids_geo_location_continent,
+                                                                      common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1449,38 +1857,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
+                                                               member_id_geo_location_region,
+                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                   type_ids_geo_location_region,
+                                                                   common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1490,7 +1908,9 @@ void register_UserInputImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1502,52 +1922,70 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1561,27 +1999,37 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
+                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -1589,30 +2037,37 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
+            type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -1625,12 +2080,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_keywords,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1642,47 +2100,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
+                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_keywords,
+                                                            common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
+                            member_ann_builtin_keywords,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
+                            detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -1695,12 +2169,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_ml_model_metadata,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1712,47 +2189,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_ml_model_metadata,
+                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_ml_model_metadata,
+                                                                 common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
+                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
+                common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1762,7 +2255,9 @@ void register_MLModelMetadataImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1774,52 +2269,70 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1833,27 +2346,37 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
+                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -1861,30 +2384,37 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
+            type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -1897,12 +2427,15 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_app_requirements,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1914,47 +2447,62 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_app_requirements,
+                                                                common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
+                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
+                common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1964,7 +2512,9 @@ void register_AppRequirementsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1976,52 +2526,70 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2035,27 +2603,37 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
+                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2063,24 +2641,30 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
+            type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2089,34 +2673,44 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                member_id_max_memory_footprint,
+                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                    type_ids_max_memory_footprint,
+                                                                    common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2126,7 +2720,9 @@ void register_HWConstraintsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2138,52 +2734,70 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2197,27 +2811,37 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
+                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2225,16 +2849,19 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2242,7 +2869,8 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2255,32 +2883,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
+                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_model_path,
+                                                              common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
+                            member_ann_builtin_model_path,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
+                            detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2293,15 +2930,19 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
+                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                         type_ids_model,
+                                                         common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2310,21 +2951,26 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
+                            member_ann_builtin_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model =
+                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2334,7 +2980,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_raw_model,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2346,41 +2994,55 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
+                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_raw_model,
+                                                             common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
+                            member_ann_builtin_raw_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
+                            detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -2393,32 +3055,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
+                                                                 member_id_model_properties_path,
+                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                     type_ids_model_properties_path,
+                                                                     common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -2431,38 +3102,47 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_model_properties,
+                                                                common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -2475,12 +3155,15 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_input_batch,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2492,41 +3175,56 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
+                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_input_batch,
+                                                               common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
+                            member_ann_builtin_input_batch,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
+                            detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -2535,34 +3233,43 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_target_latency,
+                                                              common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
+                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
+                common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2572,7 +3279,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2584,52 +3293,70 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2643,27 +3370,37 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
+                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -2671,16 +3408,19 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -2688,7 +3428,8 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -2701,32 +3442,40 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_hw_description,
+                                                              common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
+                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
+                common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -2735,28 +3484,37 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_power_consumption,
+                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_power_consumption,
+                                                                 common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -2765,11 +3523,15 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
+                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_latency,
+                                                           common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -2778,15 +3540,19 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
+                            member_ann_builtin_latency,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
+                            detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -2795,28 +3561,38 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
+                                                                        member_id_memory_footprint_of_ml_model,
+                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                            type_ids_memory_footprint_of_ml_model,
+                                                                            common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
+                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
+                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -2825,34 +3601,45 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                   member_id_max_hw_memory_footprint,
+                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                       type_ids_max_hw_memory_footprint,
+                                                                       common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2862,7 +3649,9 @@ void register_HWResourceImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2874,52 +3663,70 @@ void register_HWResourceImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2933,27 +3740,37 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
+                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -2961,24 +3778,29 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -2987,28 +3809,36 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_footprint,
+                                                                common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3017,28 +3847,37 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_energy_consumption,
+                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_energy_consumption,
+                                                                  common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3047,34 +3886,43 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_intensity,
+                                                                common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3084,7 +3932,9 @@ void register_CO2FootprintImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3096,52 +3946,70 @@ void register_CO2FootprintImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3155,25 +4023,33 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
+                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-

--- a/sustainml_cpp/include/sustainml_cpp/core/Callable.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/Callable.hpp
@@ -25,7 +25,7 @@
 #include <tuple>
 
 #include <sustainml_cpp/config/Macros.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <fastdds/dds/log/Log.hpp>
 

--- a/sustainml_cpp/include/sustainml_cpp/core/Node.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/Node.hpp
@@ -21,7 +21,7 @@
 #define SUSTAINMLCPP_CORE_NODE_HPP
 
 #include <sustainml_cpp/config/Macros.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <utility>
 #include <vector>

--- a/sustainml_cpp/include/sustainml_cpp/idl/typesImpl.idl
+++ b/sustainml_cpp/include/sustainml_cpp/idl/typesImpl.idl
@@ -98,6 +98,7 @@ struct AppRequirementsImpl
 struct HWConstraintsImpl
 {
     unsigned long max_memory_footprint;
+    sequence<string> hardware_required;
     sequence<octet> extra_data;
     @key TaskIdImpl task_id;
  };

--- a/sustainml_cpp/include/sustainml_cpp/interfaces/SampleQueryable.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/interfaces/SampleQueryable.hpp
@@ -21,7 +21,7 @@
 
 #include <vector>
 
-#include <types/types.h>
+#include <types/types.hpp>
 
 namespace sustainml {
 namespace interfaces {

--- a/sustainml_cpp/include/sustainml_cpp/nodes/AppRequirementsNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/AppRequirementsNode.hpp
@@ -22,7 +22,7 @@
 
 #include <sustainml_cpp/core/Node.hpp>
 #include <sustainml_cpp/core/Callable.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <vector>
 #include <memory>

--- a/sustainml_cpp/include/sustainml_cpp/nodes/CarbonFootprintNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/CarbonFootprintNode.hpp
@@ -22,7 +22,7 @@
 
 #include <sustainml_cpp/core/Node.hpp>
 #include <sustainml_cpp/core/Callable.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <vector>
 #include <memory>

--- a/sustainml_cpp/include/sustainml_cpp/nodes/HardwareConstraintsNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/HardwareConstraintsNode.hpp
@@ -22,7 +22,7 @@
 
 #include <sustainml_cpp/core/Node.hpp>
 #include <sustainml_cpp/core/Callable.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <vector>
 #include <memory>

--- a/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/HardwareResourcesNode.hpp
@@ -22,7 +22,7 @@
 
 #include <sustainml_cpp/core/Node.hpp>
 #include <sustainml_cpp/core/Callable.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <vector>
 #include <memory>

--- a/sustainml_cpp/include/sustainml_cpp/nodes/MLModelMetadataNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/MLModelMetadataNode.hpp
@@ -22,7 +22,7 @@
 
 #include <sustainml_cpp/core/Node.hpp>
 #include <sustainml_cpp/core/Callable.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <vector>
 #include <memory>

--- a/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/nodes/MLModelNode.hpp
@@ -22,7 +22,7 @@
 
 #include <sustainml_cpp/core/Node.hpp>
 #include <sustainml_cpp/core/Callable.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <vector>
 #include <memory>

--- a/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
@@ -24,7 +24,7 @@
 #include <mutex>
 
 #include <sustainml_cpp/core/Constants.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <fastdds/dds/domain/DomainParticipantListener.hpp>
 

--- a/sustainml_cpp/include/sustainml_cpp/types/types.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/types/types.hpp
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 /*!
- * @file types.h
+ * @file types.hpp
  *
  */
 
@@ -675,6 +675,31 @@ public:
      */
     eProsima_user_DllExport uint32_t& max_memory_footprint();
 
+    /*!
+     * @brief This function copies the value in member hardware_required
+     * @param _hardware_required New value to be copied in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            const std::vector<std::string>& _hardware_required);
+
+    /*!
+     * @brief This function moves the value in member hardware_required
+     * @param _hardware_required New value to be moved in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            std::vector<std::string>&& _hardware_required);
+
+    /*!
+     * @brief This function returns a constant reference to member hardware_required
+     * @return Constant reference to member hardware_required
+     */
+    eProsima_user_DllExport const std::vector<std::string>& hardware_required() const;
+
+    /*!
+     * @brief This function returns a reference to member hardware_required
+     * @return Reference to member hardware_required
+     */
+    eProsima_user_DllExport std::vector<std::string>& hardware_required();
 
     /*!
      * @brief This function copies the value in member extra_data

--- a/sustainml_cpp/src/cpp/common/Common.hpp
+++ b/sustainml_cpp/src/cpp/common/Common.hpp
@@ -20,7 +20,7 @@
 #define SUSTAINMLCPP_COMMON_COMMON_HPP
 
 #include <sustainml_cpp/core/Constants.hpp>
-#include <types/types.h>
+#include <types/types.hpp>
 
 #include <fastdds/dds/log/Log.hpp>
 

--- a/sustainml_cpp/src/cpp/core/NodeImpl.hpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.hpp
@@ -20,7 +20,7 @@
 #define SUSTAINMLCPP_CORE_NODE_IMPL_HPP
 
 #include <sustainml_cpp/config/Macros.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <core/Options.hpp>
 #include <types/typesImplPubSubTypes.hpp>

--- a/sustainml_cpp/src/cpp/orchestrator/Helper.hpp
+++ b/sustainml_cpp/src/cpp/orchestrator/Helper.hpp
@@ -23,7 +23,7 @@
 #include <memory>
 
 #include <sustainml_cpp/core/Constants.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <types/typesImpl.hpp>
 

--- a/sustainml_cpp/src/cpp/orchestrator/ModuleNodeProxyFactory.hpp
+++ b/sustainml_cpp/src/cpp/orchestrator/ModuleNodeProxyFactory.hpp
@@ -25,7 +25,7 @@
 #include "Helper.hpp"
 #include "ModuleNodeProxy.hpp"
 
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 
 namespace sustainml {

--- a/sustainml_cpp/src/cpp/orchestrator/TaskDB.ipp
+++ b/sustainml_cpp/src/cpp/orchestrator/TaskDB.ipp
@@ -25,7 +25,7 @@
 #include <tuple>
 
 #include <core/Constants.hpp>
-#include <types/types.h>
+#include <types/types.hpp>
 
 #include <fastdds/dds/log/Log.hpp>
 

--- a/sustainml_cpp/src/cpp/types/types.cpp
+++ b/sustainml_cpp/src/cpp/types/types.cpp
@@ -17,7 +17,7 @@
  *
  */
 
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 
 #include <common/Common.hpp>
 #include <types/typesImpl.hpp>
@@ -1273,6 +1273,7 @@ HWConstraints::HWConstraints(
     impl_ = new HWConstraintsImpl;
 
     this->impl_->max_memory_footprint() = x.impl_->max_memory_footprint();
+    this->impl_->hardware_required() = x.impl_->hardware_required();
     this->impl_->extra_data() = x.impl_->extra_data();
     this->impl_->task_id() = x.impl_->task_id();
 }
@@ -1288,6 +1289,7 @@ HWConstraints& HWConstraints::operator =(
         const HWConstraints& x)
 {
     this->impl_->max_memory_footprint() = x.impl_->max_memory_footprint();
+    this->impl_->hardware_required() = x.impl_->hardware_required();
     this->impl_->extra_data() = x.impl_->extra_data();
     this->impl_->task_id() = x.impl_->task_id();
     return *this;
@@ -1333,6 +1335,29 @@ uint32_t& HWConstraints::max_memory_footprint()
 {
     return impl_->max_memory_footprint();
 }
+
+void HWConstraints::hardware_required(
+        const std::vector<std::string>& _hardware_required)
+{
+    impl_->hardware_required(_hardware_required);
+}
+
+void HWConstraints::hardware_required(
+        std::vector<std::string>&& _hardware_required)
+{
+    impl_->hardware_required(std::forward<std::vector<std::string>>(_hardware_required));
+}
+
+const std::vector<std::string>& HWConstraints::hardware_required() const
+{
+    return impl_->hardware_required();
+}
+
+std::vector<std::string>& HWConstraints::hardware_required()
+{
+    return impl_->hardware_required();
+}
+
 
 void HWConstraints::extra_data(
         const std::vector<uint8_t>& _extra_data)

--- a/sustainml_cpp/src/cpp/types/types.cpp
+++ b/sustainml_cpp/src/cpp/types/types.cpp
@@ -1358,7 +1358,6 @@ std::vector<std::string>& HWConstraints::hardware_required()
     return impl_->hardware_required();
 }
 
-
 void HWConstraints::extra_data(
         const std::vector<uint8_t>& _extra_data)
 {

--- a/sustainml_cpp/src/cpp/types/typesImpl.hpp
+++ b/sustainml_cpp/src/cpp/types/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-               m_iteration_id == x.m_iteration_id);
+           m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,6 +209,7 @@ public:
         return m_problem_id;
     }
 
+
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -236,6 +237,8 @@ public:
     {
         return m_iteration_id;
     }
+
+
 
 private:
 
@@ -272,17 +275,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -309,17 +312,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -349,11 +352,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-               m_task_status == x.m_task_status &&
-               m_error_code == x.m_error_code &&
-               m_error_description == x.m_error_description &&
-               m_node_name == x.m_node_name &&
-               m_task_id == x.m_task_id);
+           m_task_status == x.m_task_status &&
+           m_error_code == x.m_error_code &&
+           m_error_description == x.m_error_description &&
+           m_node_name == x.m_node_name &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -394,6 +397,7 @@ public:
         return m_node_status;
     }
 
+
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -422,6 +426,7 @@ public:
         return m_task_status;
     }
 
+
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -449,6 +454,7 @@ public:
     {
         return m_error_code;
     }
+
 
     /*!
      * @brief This function copies the value in member error_description
@@ -488,6 +494,7 @@ public:
         return m_error_description;
     }
 
+
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -526,6 +533,7 @@ public:
         return m_node_name;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -563,6 +571,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -627,15 +637,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -661,15 +671,15 @@ public:
             const NodeControlImpl& x)
     {
 
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -698,10 +708,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-               m_cmd_task == x.m_cmd_task &&
-               m_target_node == x.m_target_node &&
-               m_source_node == x.m_source_node &&
-               m_task_id == x.m_task_id);
+           m_cmd_task == x.m_cmd_task &&
+           m_target_node == x.m_target_node &&
+           m_source_node == x.m_source_node &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -742,6 +752,7 @@ public:
         return m_cmd_node;
     }
 
+
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -769,6 +780,7 @@ public:
     {
         return m_cmd_task;
     }
+
 
     /*!
      * @brief This function copies the value in member target_node
@@ -808,6 +820,7 @@ public:
         return m_target_node;
     }
 
+
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -845,6 +858,7 @@ public:
     {
         return m_source_node;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -884,6 +898,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -922,35 +938,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -986,35 +1002,35 @@ public:
             const UserInputImpl& x)
     {
 
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1053,20 +1069,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-               m_problem_short_description == x.m_problem_short_description &&
-               m_problem_definition == x.m_problem_definition &&
-               m_inputs == x.m_inputs &&
-               m_outputs == x.m_outputs &&
-               m_minimum_samples == x.m_minimum_samples &&
-               m_maximum_samples == x.m_maximum_samples &&
-               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-               m_previous_iteration == x.m_previous_iteration &&
-               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-               m_geo_location_continent == x.m_geo_location_continent &&
-               m_geo_location_region == x.m_geo_location_region &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_problem_short_description == x.m_problem_short_description &&
+           m_problem_definition == x.m_problem_definition &&
+           m_inputs == x.m_inputs &&
+           m_outputs == x.m_outputs &&
+           m_minimum_samples == x.m_minimum_samples &&
+           m_maximum_samples == x.m_maximum_samples &&
+           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+           m_previous_iteration == x.m_previous_iteration &&
+           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+           m_geo_location_continent == x.m_geo_location_continent &&
+           m_geo_location_region == x.m_geo_location_region &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1117,6 +1133,7 @@ public:
         return m_modality;
     }
 
+
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1154,6 +1171,7 @@ public:
     {
         return m_problem_short_description;
     }
+
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1193,6 +1211,7 @@ public:
         return m_problem_definition;
     }
 
+
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1230,6 +1249,7 @@ public:
     {
         return m_inputs;
     }
+
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1269,6 +1289,7 @@ public:
         return m_outputs;
     }
 
+
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1296,6 +1317,7 @@ public:
     {
         return m_minimum_samples;
     }
+
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1325,6 +1347,7 @@ public:
         return m_maximum_samples;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1352,6 +1375,7 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
+
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1381,6 +1405,7 @@ public:
         return m_previous_iteration;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1409,6 +1434,7 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
+
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1436,6 +1462,7 @@ public:
     {
         return m_desired_carbon_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1475,6 +1502,7 @@ public:
         return m_geo_location_continent;
     }
 
+
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1512,6 +1540,7 @@ public:
     {
         return m_geo_location_region;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1551,6 +1580,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1588,6 +1618,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -1637,13 +1669,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1668,13 +1700,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1702,9 +1734,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-               m_ml_model_metadata == x.m_ml_model_metadata &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_ml_model_metadata == x.m_ml_model_metadata &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1755,6 +1787,7 @@ public:
         return m_keywords;
     }
 
+
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1792,6 +1825,7 @@ public:
     {
         return m_ml_model_metadata;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1831,6 +1865,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1869,6 +1904,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_keywords;
@@ -1906,11 +1943,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1934,11 +1971,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1965,8 +2002,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2017,6 +2054,7 @@ public:
         return m_app_requirements;
     }
 
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2054,6 +2092,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2093,6 +2132,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2129,11 +2170,13 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_task_id = x.m_task_id;
+                    m_extra_data = x.m_extra_data;
+
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2145,6 +2188,7 @@ public:
             HWConstraintsImpl&& x) noexcept
     {
         m_max_memory_footprint = x.m_max_memory_footprint;
+        m_hardware_required = std::move(x.m_hardware_required);
         m_extra_data = std::move(x.m_extra_data);
         m_task_id = std::move(x.m_task_id);
     }
@@ -2157,11 +2201,13 @@ public:
             const HWConstraintsImpl& x)
     {
 
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_task_id = x.m_task_id;
+                    m_extra_data = x.m_extra_data;
+
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2175,6 +2221,7 @@ public:
     {
 
         m_max_memory_footprint = x.m_max_memory_footprint;
+        m_hardware_required = std::move(x.m_hardware_required);
         m_extra_data = std::move(x.m_extra_data);
         m_task_id = std::move(x.m_task_id);
         return *this;
@@ -2188,8 +2235,9 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_hardware_required == x.m_hardware_required &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2230,6 +2278,46 @@ public:
         return m_max_memory_footprint;
     }
 
+
+    /*!
+     * @brief This function copies the value in member hardware_required
+     * @param _hardware_required New value to be copied in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            const std::vector<std::string>& _hardware_required)
+    {
+        m_hardware_required = _hardware_required;
+    }
+
+    /*!
+     * @brief This function moves the value in member hardware_required
+     * @param _hardware_required New value to be moved in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            std::vector<std::string>&& _hardware_required)
+    {
+        m_hardware_required = std::move(_hardware_required);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member hardware_required
+     * @return Constant reference to member hardware_required
+     */
+    eProsima_user_DllExport const std::vector<std::string>& hardware_required() const
+    {
+        return m_hardware_required;
+    }
+
+    /*!
+     * @brief This function returns a reference to member hardware_required
+     * @return Reference to member hardware_required
+     */
+    eProsima_user_DllExport std::vector<std::string>& hardware_required()
+    {
+        return m_hardware_required;
+    }
+
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2267,6 +2355,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2306,9 +2395,12 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     uint32_t m_max_memory_footprint{0};
+    std::vector<std::string> m_hardware_required;
     std::vector<uint8_t> m_extra_data;
     TaskIdImpl m_task_id;
 
@@ -2342,23 +2434,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2388,23 +2480,23 @@ public:
             const MLModelImpl& x)
     {
 
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2437,14 +2529,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-               m_model == x.m_model &&
-               m_raw_model == x.m_raw_model &&
-               m_model_properties_path == x.m_model_properties_path &&
-               m_model_properties == x.m_model_properties &&
-               m_input_batch == x.m_input_batch &&
-               m_target_latency == x.m_target_latency &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_model == x.m_model &&
+           m_raw_model == x.m_raw_model &&
+           m_model_properties_path == x.m_model_properties_path &&
+           m_model_properties == x.m_model_properties &&
+           m_input_batch == x.m_input_batch &&
+           m_target_latency == x.m_target_latency &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2495,6 +2587,7 @@ public:
         return m_model_path;
     }
 
+
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2532,6 +2625,7 @@ public:
     {
         return m_model;
     }
+
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2571,6 +2665,7 @@ public:
         return m_raw_model;
     }
 
+
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2608,6 +2703,7 @@ public:
     {
         return m_model_properties_path;
     }
+
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2647,6 +2743,7 @@ public:
         return m_model_properties;
     }
 
+
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2685,6 +2782,7 @@ public:
         return m_input_batch;
     }
 
+
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2712,6 +2810,7 @@ public:
     {
         return m_target_latency;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2751,6 +2850,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2788,6 +2888,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -2831,19 +2933,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2871,19 +2973,19 @@ public:
             const HWResourceImpl& x)
     {
 
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2914,12 +3016,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-               m_power_consumption == x.m_power_consumption &&
-               m_latency == x.m_latency &&
-               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_power_consumption == x.m_power_consumption &&
+           m_latency == x.m_latency &&
+           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2970,6 +3072,7 @@ public:
         return m_hw_description;
     }
 
+
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -2997,6 +3100,7 @@ public:
     {
         return m_power_consumption;
     }
+
 
     /*!
      * @brief This function sets a value in member latency
@@ -3026,6 +3130,7 @@ public:
         return m_latency;
     }
 
+
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3054,6 +3159,7 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
+
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3081,6 +3187,7 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3120,6 +3227,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3157,6 +3265,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -3198,15 +3308,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -3232,15 +3342,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3269,10 +3379,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-               m_energy_consumption == x.m_energy_consumption &&
-               m_carbon_intensity == x.m_carbon_intensity &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_energy_consumption == x.m_energy_consumption &&
+           m_carbon_intensity == x.m_carbon_intensity &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3313,6 +3423,7 @@ public:
         return m_carbon_footprint;
     }
 
+
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3341,6 +3452,7 @@ public:
         return m_energy_consumption;
     }
 
+
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3368,6 +3480,7 @@ public:
     {
         return m_carbon_intensity;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3407,6 +3520,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3444,6 +3558,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 

--- a/sustainml_cpp/src/cpp/types/typesImpl.hpp
+++ b/sustainml_cpp/src/cpp/types/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-                    m_problem_id = x.m_problem_id;
+        m_problem_id = x.m_problem_id;
 
-                    m_iteration_id = x.m_iteration_id;
+        m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-                    m_problem_id = x.m_problem_id;
+        m_problem_id = x.m_problem_id;
 
-                    m_iteration_id = x.m_iteration_id;
+        m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-           m_iteration_id == x.m_iteration_id);
+               m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,7 +209,6 @@ public:
         return m_problem_id;
     }
 
-
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -237,8 +236,6 @@ public:
     {
         return m_iteration_id;
     }
-
-
 
 private:
 
@@ -275,17 +272,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-                    m_node_status = x.m_node_status;
+        m_node_status = x.m_node_status;
 
-                    m_task_status = x.m_task_status;
+        m_task_status = x.m_task_status;
 
-                    m_error_code = x.m_error_code;
+        m_error_code = x.m_error_code;
 
-                    m_error_description = x.m_error_description;
+        m_error_description = x.m_error_description;
 
-                    m_node_name = x.m_node_name;
+        m_node_name = x.m_node_name;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -312,17 +309,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-                    m_node_status = x.m_node_status;
+        m_node_status = x.m_node_status;
 
-                    m_task_status = x.m_task_status;
+        m_task_status = x.m_task_status;
 
-                    m_error_code = x.m_error_code;
+        m_error_code = x.m_error_code;
 
-                    m_error_description = x.m_error_description;
+        m_error_description = x.m_error_description;
 
-                    m_node_name = x.m_node_name;
+        m_node_name = x.m_node_name;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -352,11 +349,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-           m_task_status == x.m_task_status &&
-           m_error_code == x.m_error_code &&
-           m_error_description == x.m_error_description &&
-           m_node_name == x.m_node_name &&
-           m_task_id == x.m_task_id);
+               m_task_status == x.m_task_status &&
+               m_error_code == x.m_error_code &&
+               m_error_description == x.m_error_description &&
+               m_node_name == x.m_node_name &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -397,7 +394,6 @@ public:
         return m_node_status;
     }
 
-
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -426,7 +422,6 @@ public:
         return m_task_status;
     }
 
-
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -454,7 +449,6 @@ public:
     {
         return m_error_code;
     }
-
 
     /*!
      * @brief This function copies the value in member error_description
@@ -494,7 +488,6 @@ public:
         return m_error_description;
     }
 
-
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -533,7 +526,6 @@ public:
         return m_node_name;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -571,8 +563,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -637,15 +627,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-                    m_cmd_node = x.m_cmd_node;
+        m_cmd_node = x.m_cmd_node;
 
-                    m_cmd_task = x.m_cmd_task;
+        m_cmd_task = x.m_cmd_task;
 
-                    m_target_node = x.m_target_node;
+        m_target_node = x.m_target_node;
 
-                    m_source_node = x.m_source_node;
+        m_source_node = x.m_source_node;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -671,15 +661,15 @@ public:
             const NodeControlImpl& x)
     {
 
-                    m_cmd_node = x.m_cmd_node;
+        m_cmd_node = x.m_cmd_node;
 
-                    m_cmd_task = x.m_cmd_task;
+        m_cmd_task = x.m_cmd_task;
 
-                    m_target_node = x.m_target_node;
+        m_target_node = x.m_target_node;
 
-                    m_source_node = x.m_source_node;
+        m_source_node = x.m_source_node;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -708,10 +698,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-           m_cmd_task == x.m_cmd_task &&
-           m_target_node == x.m_target_node &&
-           m_source_node == x.m_source_node &&
-           m_task_id == x.m_task_id);
+               m_cmd_task == x.m_cmd_task &&
+               m_target_node == x.m_target_node &&
+               m_source_node == x.m_source_node &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -752,7 +742,6 @@ public:
         return m_cmd_node;
     }
 
-
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -780,7 +769,6 @@ public:
     {
         return m_cmd_task;
     }
-
 
     /*!
      * @brief This function copies the value in member target_node
@@ -820,7 +808,6 @@ public:
         return m_target_node;
     }
 
-
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -858,7 +845,6 @@ public:
     {
         return m_source_node;
     }
-
 
     /*!
      * @brief This function copies the value in member task_id
@@ -898,8 +884,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -938,35 +922,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-                    m_modality = x.m_modality;
+        m_modality = x.m_modality;
 
-                    m_problem_short_description = x.m_problem_short_description;
+        m_problem_short_description = x.m_problem_short_description;
 
-                    m_problem_definition = x.m_problem_definition;
+        m_problem_definition = x.m_problem_definition;
 
-                    m_inputs = x.m_inputs;
+        m_inputs = x.m_inputs;
 
-                    m_outputs = x.m_outputs;
+        m_outputs = x.m_outputs;
 
-                    m_minimum_samples = x.m_minimum_samples;
+        m_minimum_samples = x.m_minimum_samples;
 
-                    m_maximum_samples = x.m_maximum_samples;
+        m_maximum_samples = x.m_maximum_samples;
 
-                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-                    m_previous_iteration = x.m_previous_iteration;
+        m_previous_iteration = x.m_previous_iteration;
 
-                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-                    m_geo_location_continent = x.m_geo_location_continent;
+        m_geo_location_continent = x.m_geo_location_continent;
 
-                    m_geo_location_region = x.m_geo_location_region;
+        m_geo_location_region = x.m_geo_location_region;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1002,35 +986,35 @@ public:
             const UserInputImpl& x)
     {
 
-                    m_modality = x.m_modality;
+        m_modality = x.m_modality;
 
-                    m_problem_short_description = x.m_problem_short_description;
+        m_problem_short_description = x.m_problem_short_description;
 
-                    m_problem_definition = x.m_problem_definition;
+        m_problem_definition = x.m_problem_definition;
 
-                    m_inputs = x.m_inputs;
+        m_inputs = x.m_inputs;
 
-                    m_outputs = x.m_outputs;
+        m_outputs = x.m_outputs;
 
-                    m_minimum_samples = x.m_minimum_samples;
+        m_minimum_samples = x.m_minimum_samples;
 
-                    m_maximum_samples = x.m_maximum_samples;
+        m_maximum_samples = x.m_maximum_samples;
 
-                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-                    m_previous_iteration = x.m_previous_iteration;
+        m_previous_iteration = x.m_previous_iteration;
 
-                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-                    m_geo_location_continent = x.m_geo_location_continent;
+        m_geo_location_continent = x.m_geo_location_continent;
 
-                    m_geo_location_region = x.m_geo_location_region;
+        m_geo_location_region = x.m_geo_location_region;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1069,20 +1053,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-           m_problem_short_description == x.m_problem_short_description &&
-           m_problem_definition == x.m_problem_definition &&
-           m_inputs == x.m_inputs &&
-           m_outputs == x.m_outputs &&
-           m_minimum_samples == x.m_minimum_samples &&
-           m_maximum_samples == x.m_maximum_samples &&
-           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-           m_previous_iteration == x.m_previous_iteration &&
-           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-           m_geo_location_continent == x.m_geo_location_continent &&
-           m_geo_location_region == x.m_geo_location_region &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_problem_short_description == x.m_problem_short_description &&
+               m_problem_definition == x.m_problem_definition &&
+               m_inputs == x.m_inputs &&
+               m_outputs == x.m_outputs &&
+               m_minimum_samples == x.m_minimum_samples &&
+               m_maximum_samples == x.m_maximum_samples &&
+               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+               m_previous_iteration == x.m_previous_iteration &&
+               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+               m_geo_location_continent == x.m_geo_location_continent &&
+               m_geo_location_region == x.m_geo_location_region &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1133,7 +1117,6 @@ public:
         return m_modality;
     }
 
-
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1171,7 +1154,6 @@ public:
     {
         return m_problem_short_description;
     }
-
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1211,7 +1193,6 @@ public:
         return m_problem_definition;
     }
 
-
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1249,7 +1230,6 @@ public:
     {
         return m_inputs;
     }
-
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1289,7 +1269,6 @@ public:
         return m_outputs;
     }
 
-
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1317,7 +1296,6 @@ public:
     {
         return m_minimum_samples;
     }
-
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1347,7 +1325,6 @@ public:
         return m_maximum_samples;
     }
 
-
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1375,7 +1352,6 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
-
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1405,7 +1381,6 @@ public:
         return m_previous_iteration;
     }
 
-
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1434,7 +1409,6 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
-
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1462,7 +1436,6 @@ public:
     {
         return m_desired_carbon_footprint;
     }
-
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1502,7 +1475,6 @@ public:
         return m_geo_location_continent;
     }
 
-
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1540,7 +1512,6 @@ public:
     {
         return m_geo_location_region;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1580,7 +1551,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1618,8 +1588,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -1669,13 +1637,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-                    m_keywords = x.m_keywords;
+        m_keywords = x.m_keywords;
 
-                    m_ml_model_metadata = x.m_ml_model_metadata;
+        m_ml_model_metadata = x.m_ml_model_metadata;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1700,13 +1668,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-                    m_keywords = x.m_keywords;
+        m_keywords = x.m_keywords;
 
-                    m_ml_model_metadata = x.m_ml_model_metadata;
+        m_ml_model_metadata = x.m_ml_model_metadata;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1734,9 +1702,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-           m_ml_model_metadata == x.m_ml_model_metadata &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_ml_model_metadata == x.m_ml_model_metadata &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1787,7 +1755,6 @@ public:
         return m_keywords;
     }
 
-
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1825,7 +1792,6 @@ public:
     {
         return m_ml_model_metadata;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1865,7 +1831,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1904,8 +1869,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     std::vector<std::string> m_keywords;
@@ -1943,11 +1906,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-                    m_app_requirements = x.m_app_requirements;
+        m_app_requirements = x.m_app_requirements;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1971,11 +1934,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-                    m_app_requirements = x.m_app_requirements;
+        m_app_requirements = x.m_app_requirements;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2002,8 +1965,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2054,7 +2017,6 @@ public:
         return m_app_requirements;
     }
 
-
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2092,7 +2054,6 @@ public:
     {
         return m_extra_data;
     }
-
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2132,8 +2093,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2170,13 +2129,13 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-                    m_max_memory_footprint = x.m_max_memory_footprint;
+        m_max_memory_footprint = x.m_max_memory_footprint;
 
-                    m_hardware_required = x.m_hardware_required;
+        m_hardware_required = x.m_hardware_required;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2201,13 +2160,13 @@ public:
             const HWConstraintsImpl& x)
     {
 
-                    m_max_memory_footprint = x.m_max_memory_footprint;
+        m_max_memory_footprint = x.m_max_memory_footprint;
 
-                    m_hardware_required = x.m_hardware_required;
+        m_hardware_required = x.m_hardware_required;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2235,9 +2194,9 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-           m_hardware_required == x.m_hardware_required &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_hardware_required == x.m_hardware_required &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2278,7 +2237,6 @@ public:
         return m_max_memory_footprint;
     }
 
-
     /*!
      * @brief This function copies the value in member hardware_required
      * @param _hardware_required New value to be copied in member hardware_required
@@ -2316,7 +2274,6 @@ public:
     {
         return m_hardware_required;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2356,7 +2313,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2395,8 +2351,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     uint32_t m_max_memory_footprint{0};
@@ -2434,23 +2388,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-                    m_model_path = x.m_model_path;
+        m_model_path = x.m_model_path;
 
-                    m_model = x.m_model;
+        m_model = x.m_model;
 
-                    m_raw_model = x.m_raw_model;
+        m_raw_model = x.m_raw_model;
 
-                    m_model_properties_path = x.m_model_properties_path;
+        m_model_properties_path = x.m_model_properties_path;
 
-                    m_model_properties = x.m_model_properties;
+        m_model_properties = x.m_model_properties;
 
-                    m_input_batch = x.m_input_batch;
+        m_input_batch = x.m_input_batch;
 
-                    m_target_latency = x.m_target_latency;
+        m_target_latency = x.m_target_latency;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2480,23 +2434,23 @@ public:
             const MLModelImpl& x)
     {
 
-                    m_model_path = x.m_model_path;
+        m_model_path = x.m_model_path;
 
-                    m_model = x.m_model;
+        m_model = x.m_model;
 
-                    m_raw_model = x.m_raw_model;
+        m_raw_model = x.m_raw_model;
 
-                    m_model_properties_path = x.m_model_properties_path;
+        m_model_properties_path = x.m_model_properties_path;
 
-                    m_model_properties = x.m_model_properties;
+        m_model_properties = x.m_model_properties;
 
-                    m_input_batch = x.m_input_batch;
+        m_input_batch = x.m_input_batch;
 
-                    m_target_latency = x.m_target_latency;
+        m_target_latency = x.m_target_latency;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2529,14 +2483,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-           m_model == x.m_model &&
-           m_raw_model == x.m_raw_model &&
-           m_model_properties_path == x.m_model_properties_path &&
-           m_model_properties == x.m_model_properties &&
-           m_input_batch == x.m_input_batch &&
-           m_target_latency == x.m_target_latency &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_model == x.m_model &&
+               m_raw_model == x.m_raw_model &&
+               m_model_properties_path == x.m_model_properties_path &&
+               m_model_properties == x.m_model_properties &&
+               m_input_batch == x.m_input_batch &&
+               m_target_latency == x.m_target_latency &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2587,7 +2541,6 @@ public:
         return m_model_path;
     }
 
-
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2625,7 +2578,6 @@ public:
     {
         return m_model;
     }
-
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2665,7 +2617,6 @@ public:
         return m_raw_model;
     }
 
-
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2703,7 +2654,6 @@ public:
     {
         return m_model_properties_path;
     }
-
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2743,7 +2693,6 @@ public:
         return m_model_properties;
     }
 
-
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2782,7 +2731,6 @@ public:
         return m_input_batch;
     }
 
-
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2810,7 +2758,6 @@ public:
     {
         return m_target_latency;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2850,7 +2797,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2888,8 +2834,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -2933,19 +2877,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-                    m_hw_description = x.m_hw_description;
+        m_hw_description = x.m_hw_description;
 
-                    m_power_consumption = x.m_power_consumption;
+        m_power_consumption = x.m_power_consumption;
 
-                    m_latency = x.m_latency;
+        m_latency = x.m_latency;
 
-                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2973,19 +2917,19 @@ public:
             const HWResourceImpl& x)
     {
 
-                    m_hw_description = x.m_hw_description;
+        m_hw_description = x.m_hw_description;
 
-                    m_power_consumption = x.m_power_consumption;
+        m_power_consumption = x.m_power_consumption;
 
-                    m_latency = x.m_latency;
+        m_latency = x.m_latency;
 
-                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3016,12 +2960,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-           m_power_consumption == x.m_power_consumption &&
-           m_latency == x.m_latency &&
-           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_power_consumption == x.m_power_consumption &&
+               m_latency == x.m_latency &&
+               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3072,7 +3016,6 @@ public:
         return m_hw_description;
     }
 
-
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -3100,7 +3043,6 @@ public:
     {
         return m_power_consumption;
     }
-
 
     /*!
      * @brief This function sets a value in member latency
@@ -3130,7 +3072,6 @@ public:
         return m_latency;
     }
 
-
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3159,7 +3100,6 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
-
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3187,7 +3127,6 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3227,7 +3166,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3265,8 +3203,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -3308,15 +3244,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-                    m_carbon_footprint = x.m_carbon_footprint;
+        m_carbon_footprint = x.m_carbon_footprint;
 
-                    m_energy_consumption = x.m_energy_consumption;
+        m_energy_consumption = x.m_energy_consumption;
 
-                    m_carbon_intensity = x.m_carbon_intensity;
+        m_carbon_intensity = x.m_carbon_intensity;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -3342,15 +3278,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-                    m_carbon_footprint = x.m_carbon_footprint;
+        m_carbon_footprint = x.m_carbon_footprint;
 
-                    m_energy_consumption = x.m_energy_consumption;
+        m_energy_consumption = x.m_energy_consumption;
 
-                    m_carbon_intensity = x.m_carbon_intensity;
+        m_carbon_intensity = x.m_carbon_intensity;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3379,10 +3315,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-           m_energy_consumption == x.m_energy_consumption &&
-           m_carbon_intensity == x.m_carbon_intensity &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_energy_consumption == x.m_energy_consumption &&
+               m_carbon_intensity == x.m_carbon_intensity &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3423,7 +3359,6 @@ public:
         return m_carbon_footprint;
     }
 
-
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3452,7 +3387,6 @@ public:
         return m_energy_consumption;
     }
 
-
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3480,7 +3414,6 @@ public:
     {
         return m_carbon_intensity;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3520,7 +3453,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3558,8 +3490,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 

--- a/sustainml_cpp/src/cpp/types/typesImplCdrAux.hpp
+++ b/sustainml_cpp/src/cpp/types/typesImplCdrAux.hpp
@@ -36,7 +36,7 @@ constexpr uint32_t MLModelImpl_max_key_cdr_typesize {12UL};
 constexpr uint32_t MLModelMetadataImpl_max_cdr_typesize {36UL};
 constexpr uint32_t MLModelMetadataImpl_max_key_cdr_typesize {12UL};
 
-constexpr uint32_t HWConstraintsImpl_max_cdr_typesize {24UL};
+constexpr uint32_t HWConstraintsImpl_max_cdr_typesize {32UL};
 constexpr uint32_t HWConstraintsImpl_max_key_cdr_typesize {12UL};
 
 constexpr uint32_t CO2FootprintImpl_max_cdr_typesize {48UL};

--- a/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
+++ b/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
@@ -50,11 +50,11 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.problem_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.problem_id(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.iteration_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.iteration_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -76,7 +76,7 @@ eProsima_user_DllExport void serialize(
     scdr
         << eprosima::fastcdr::MemberId(0) << data.problem_id()
         << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -93,13 +93,13 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.problem_id();
-                        break;
+                                        case 0:
+                                                dcdr >> data.problem_id();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.iteration_id();
-                        break;
+                                        case 1:
+                                                dcdr >> data.iteration_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -116,11 +116,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.problem_id();
+                        scdr << data.problem_id();
 
-    scdr << data.iteration_id();
+                        scdr << data.iteration_id();
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -138,23 +139,23 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.node_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.task_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.task_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.error_code(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.error_code(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.error_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.error_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.node_name(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.node_name(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -180,7 +181,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(3) << data.error_description()
         << eprosima::fastcdr::MemberId(4) << data.node_name()
         << eprosima::fastcdr::MemberId(5) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -197,29 +198,29 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.node_status();
-                        break;
+                                        case 0:
+                                                dcdr >> data.node_status();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.task_status();
-                        break;
+                                        case 1:
+                                                dcdr >> data.task_status();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.error_code();
-                        break;
+                                        case 2:
+                                                dcdr >> data.error_code();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.error_description();
-                        break;
+                                        case 3:
+                                                dcdr >> data.error_description();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.node_name();
-                        break;
+                                        case 4:
+                                                dcdr >> data.node_name();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 5:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -233,18 +234,21 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.node_name();
+                        scdr << data.node_name();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
+
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -262,20 +266,20 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.cmd_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.cmd_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.cmd_task(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.cmd_task(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.target_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.target_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.source_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.source_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -300,7 +304,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.target_node()
         << eprosima::fastcdr::MemberId(3) << data.source_node()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -317,25 +321,25 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.cmd_node();
-                        break;
+                                        case 0:
+                                                dcdr >> data.cmd_node();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.cmd_task();
-                        break;
+                                        case 1:
+                                                dcdr >> data.cmd_task();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.target_node();
-                        break;
+                                        case 2:
+                                                dcdr >> data.target_node();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.source_node();
-                        break;
+                                        case 3:
+                                                dcdr >> data.source_node();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -349,18 +353,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.source_node();
+                        scdr << data.source_node();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -378,50 +383,50 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.modality(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.modality(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.problem_short_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.problem_short_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.problem_definition(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.problem_definition(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.inputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.inputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.outputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.outputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.minimum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.minimum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.maximum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.maximum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.optimize_carbon_footprint_manual(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.optimize_carbon_footprint_manual(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.previous_iteration(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.previous_iteration(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                    data.optimize_carbon_footprint_auto(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                data.optimize_carbon_footprint_auto(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                    data.desired_carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                data.desired_carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                    data.geo_location_continent(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                data.geo_location_continent(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                    data.geo_location_region(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                data.geo_location_region(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -456,7 +461,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
         << eprosima::fastcdr::MemberId(13) << data.extra_data()
         << eprosima::fastcdr::MemberId(14) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -473,65 +478,65 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.modality();
-                        break;
+                                        case 0:
+                                                dcdr >> data.modality();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.problem_short_description();
-                        break;
+                                        case 1:
+                                                dcdr >> data.problem_short_description();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.problem_definition();
-                        break;
+                                        case 2:
+                                                dcdr >> data.problem_definition();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.inputs();
-                        break;
+                                        case 3:
+                                                dcdr >> data.inputs();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.outputs();
-                        break;
+                                        case 4:
+                                                dcdr >> data.outputs();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.minimum_samples();
-                        break;
+                                        case 5:
+                                                dcdr >> data.minimum_samples();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.maximum_samples();
-                        break;
+                                        case 6:
+                                                dcdr >> data.maximum_samples();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.optimize_carbon_footprint_manual();
-                        break;
+                                        case 7:
+                                                dcdr >> data.optimize_carbon_footprint_manual();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.previous_iteration();
-                        break;
+                                        case 8:
+                                                dcdr >> data.previous_iteration();
+                                            break;
 
-                    case 9:
-                        dcdr >> data.optimize_carbon_footprint_auto();
-                        break;
+                                        case 9:
+                                                dcdr >> data.optimize_carbon_footprint_auto();
+                                            break;
 
-                    case 10:
-                        dcdr >> data.desired_carbon_footprint();
-                        break;
+                                        case 10:
+                                                dcdr >> data.desired_carbon_footprint();
+                                            break;
 
-                    case 11:
-                        dcdr >> data.geo_location_continent();
-                        break;
+                                        case 11:
+                                                dcdr >> data.geo_location_continent();
+                                            break;
 
-                    case 12:
-                        dcdr >> data.geo_location_region();
-                        break;
+                                        case 12:
+                                                dcdr >> data.geo_location_region();
+                                            break;
 
-                    case 13:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 13:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 14:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 14:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -545,16 +550,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UserInputImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -572,17 +578,17 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.keywords(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.keywords(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.ml_model_metadata(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.ml_model_metadata(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -606,7 +612,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
         << eprosima::fastcdr::MemberId(2) << data.extra_data()
         << eprosima::fastcdr::MemberId(3) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -623,21 +629,21 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.keywords();
-                        break;
+                                        case 0:
+                                                dcdr >> data.keywords();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.ml_model_metadata();
-                        break;
+                                        case 1:
+                                                dcdr >> data.ml_model_metadata();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -651,16 +657,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelMetadataImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -678,14 +685,14 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.app_requirements(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.app_requirements(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -708,7 +715,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(0) << data.app_requirements()
         << eprosima::fastcdr::MemberId(1) << data.extra_data()
         << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -725,17 +732,17 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.app_requirements();
-                        break;
+                                        case 0:
+                                                dcdr >> data.app_requirements();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -749,16 +756,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppRequirementsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -776,14 +784,17 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.max_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.max_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.hardware_required(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -804,9 +815,10 @@ eProsima_user_DllExport void serialize(
 
     scdr
         << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.extra_data()
-        << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -823,17 +835,21 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.max_memory_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.max_memory_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.hardware_required();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
+
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -847,16 +863,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWConstraintsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -874,32 +891,32 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.model_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.model_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.raw_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.raw_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.model_properties_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.model_properties_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.model_properties(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.model_properties(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.input_batch(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.input_batch(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.target_latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.target_latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -928,7 +945,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(6) << data.target_latency()
         << eprosima::fastcdr::MemberId(7) << data.extra_data()
         << eprosima::fastcdr::MemberId(8) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -945,41 +962,41 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.model_path();
-                        break;
+                                        case 0:
+                                                dcdr >> data.model_path();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.model();
-                        break;
+                                        case 1:
+                                                dcdr >> data.model();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.raw_model();
-                        break;
+                                        case 2:
+                                                dcdr >> data.raw_model();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.model_properties_path();
-                        break;
+                                        case 3:
+                                                dcdr >> data.model_properties_path();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.model_properties();
-                        break;
+                                        case 4:
+                                                dcdr >> data.model_properties();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.input_batch();
-                        break;
+                                        case 5:
+                                                dcdr >> data.input_batch();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.target_latency();
-                        break;
+                                        case 6:
+                                                dcdr >> data.target_latency();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 7:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 8:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -993,16 +1010,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -1020,26 +1038,26 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.hw_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.hw_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.power_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.power_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.memory_footprint_of_ml_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.memory_footprint_of_ml_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.max_hw_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.max_hw_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1066,7 +1084,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
         << eprosima::fastcdr::MemberId(5) << data.extra_data()
         << eprosima::fastcdr::MemberId(6) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -1083,33 +1101,33 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.hw_description();
-                        break;
+                                        case 0:
+                                                dcdr >> data.hw_description();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.power_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.power_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.latency();
-                        break;
+                                        case 2:
+                                                dcdr >> data.latency();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.memory_footprint_of_ml_model();
-                        break;
+                                        case 3:
+                                                dcdr >> data.memory_footprint_of_ml_model();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.max_hw_memory_footprint();
-                        break;
+                                        case 4:
+                                                dcdr >> data.max_hw_memory_footprint();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 5:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 6:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1123,16 +1141,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWResourceImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -1150,20 +1169,20 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.energy_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.energy_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.carbon_intensity(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.carbon_intensity(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1188,7 +1207,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
         << eprosima::fastcdr::MemberId(3) << data.extra_data()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -1205,25 +1224,25 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.carbon_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.carbon_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.energy_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.energy_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.carbon_intensity();
-                        break;
+                                        case 2:
+                                                dcdr >> data.carbon_intensity();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 3:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1237,16 +1256,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
+
 
 } // namespace fastcdr
 } // namespace eprosima

--- a/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
+++ b/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
@@ -32,66 +32,66 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-    namespace fastcdr {
+namespace fastcdr {
 
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const TaskIdImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const TaskIdImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
-
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.problem_id(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.iteration_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.problem_id(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.iteration_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.problem_id()
-                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                TaskIdImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.problem_id()
+        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        TaskIdImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -110,95 +110,95 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.problem_id();
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.problem_id();
 
-            scdr << data.iteration_id();
+    scdr << data.iteration_id();
 
-        }
+}
 
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeStatusImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeStatusImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
-
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.node_status(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.task_status(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.error_code(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.error_description(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.node_name(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.node_status(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.task_status(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.error_code(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.node_status()
-                << eprosima::fastcdr::MemberId(1) << data.task_status()
-                << eprosima::fastcdr::MemberId(2) << data.error_code()
-                << eprosima::fastcdr::MemberId(3) << data.error_description()
-                << eprosima::fastcdr::MemberId(4) << data.node_name()
-                << eprosima::fastcdr::MemberId(5) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.error_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeStatusImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.node_name(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.node_status()
+        << eprosima::fastcdr::MemberId(1) << data.task_status()
+        << eprosima::fastcdr::MemberId(2) << data.error_code()
+        << eprosima::fastcdr::MemberId(3) << data.error_description()
+        << eprosima::fastcdr::MemberId(4) << data.node_name()
+        << eprosima::fastcdr::MemberId(5) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeStatusImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -233,95 +233,95 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.node_name();
-
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeControlImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.cmd_node(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.node_name();
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.cmd_task(), current_alignment);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.target_node(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.source_node(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeControlImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.cmd_node(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.cmd_task(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.target_node(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-                << eprosima::fastcdr::MemberId(2) << data.target_node()
-                << eprosima::fastcdr::MemberId(3) << data.source_node()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.source_node(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeControlImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+        << eprosima::fastcdr::MemberId(2) << data.target_node()
+        << eprosima::fastcdr::MemberId(3) << data.source_node()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeControlImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -352,135 +352,135 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.source_node();
-
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const UserInputImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.modality(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.source_node();
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.problem_short_description(), current_alignment);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.problem_definition(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.inputs(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const UserInputImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.outputs(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.minimum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.maximum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.optimize_carbon_footprint_manual(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.previous_iteration(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                            data.optimize_carbon_footprint_auto(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                            data.desired_carbon_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                            data.geo_location_continent(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                            data.geo_location_region(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.modality(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.problem_short_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.problem_definition(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.modality()
-                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-                << eprosima::fastcdr::MemberId(3) << data.inputs()
-                << eprosima::fastcdr::MemberId(4) << data.outputs()
-                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-                << eprosima::fastcdr::MemberId(13) << data.extra_data()
-                << eprosima::fastcdr::MemberId(14) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.inputs(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                UserInputImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.outputs(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.minimum_samples(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.maximum_samples(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    data.optimize_carbon_footprint_manual(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    data.previous_iteration(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                    data.optimize_carbon_footprint_auto(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                    data.desired_carbon_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                    data.geo_location_continent(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                    data.geo_location_region(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.modality()
+        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+        << eprosima::fastcdr::MemberId(3) << data.inputs()
+        << eprosima::fastcdr::MemberId(4) << data.outputs()
+        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+        << eprosima::fastcdr::MemberId(13) << data.extra_data()
+        << eprosima::fastcdr::MemberId(14) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        UserInputImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -551,89 +551,89 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelMetadataImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.keywords(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.ml_model_metadata(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.extra_data(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelMetadataImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.keywords(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.ml_model_metadata(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.extra_data(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.keywords()
-                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-                << eprosima::fastcdr::MemberId(2) << data.extra_data()
-                << eprosima::fastcdr::MemberId(3) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.task_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelMetadataImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.keywords()
+        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelMetadataImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -660,85 +660,85 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const AppRequirementsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.app_requirements(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.extra_data(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.task_id(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const AppRequirementsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.app_requirements(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.extra_data(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.task_id(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-                << eprosima::fastcdr::MemberId(1) << data.extra_data()
-                << eprosima::fastcdr::MemberId(2) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                AppRequirementsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+        << eprosima::fastcdr::MemberId(1) << data.extra_data()
+        << eprosima::fastcdr::MemberId(2) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        AppRequirementsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -761,89 +761,89 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWConstraintsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.max_memory_footprint(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.hardware_required(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.extra_data(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWConstraintsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.max_memory_footprint(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.hardware_required(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.extra_data(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.hardware_required()
-                << eprosima::fastcdr::MemberId(2) << data.extra_data()
-                << eprosima::fastcdr::MemberId(3) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.task_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWConstraintsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWConstraintsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -870,109 +870,109 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.model_path(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.model(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.raw_model(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.model_properties_path(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.model_properties(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.input_batch(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.target_latency(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.model_path(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.raw_model(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.model_path()
-                << eprosima::fastcdr::MemberId(1) << data.model()
-                << eprosima::fastcdr::MemberId(2) << data.raw_model()
-                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-                << eprosima::fastcdr::MemberId(4) << data.model_properties()
-                << eprosima::fastcdr::MemberId(5) << data.input_batch()
-                << eprosima::fastcdr::MemberId(6) << data.target_latency()
-                << eprosima::fastcdr::MemberId(7) << data.extra_data()
-                << eprosima::fastcdr::MemberId(8) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.model_properties_path(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.model_properties(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.input_batch(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.target_latency(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.model_path()
+        << eprosima::fastcdr::MemberId(1) << data.model()
+        << eprosima::fastcdr::MemberId(2) << data.raw_model()
+        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+        << eprosima::fastcdr::MemberId(4) << data.model_properties()
+        << eprosima::fastcdr::MemberId(5) << data.input_batch()
+        << eprosima::fastcdr::MemberId(6) << data.target_latency()
+        << eprosima::fastcdr::MemberId(7) << data.extra_data()
+        << eprosima::fastcdr::MemberId(8) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1019,101 +1019,101 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWResourceImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.hw_description(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.power_consumption(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.latency(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWResourceImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.memory_footprint_of_ml_model(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.max_hw_memory_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.hw_description(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.power_consumption(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.latency(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.hw_description()
-                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.latency()
-                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-                << eprosima::fastcdr::MemberId(5) << data.extra_data()
-                << eprosima::fastcdr::MemberId(6) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.memory_footprint_of_ml_model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWResourceImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.max_hw_memory_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.hw_description()
+        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.latency()
+        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+        << eprosima::fastcdr::MemberId(5) << data.extra_data()
+        << eprosima::fastcdr::MemberId(6) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWResourceImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1152,93 +1152,93 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const CO2FootprintImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.carbon_footprint(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.energy_consumption(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.carbon_intensity(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const CO2FootprintImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.extra_data(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.carbon_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.energy_consumption(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.carbon_intensity(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.task_id(), current_alignment);
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-            return calculated_size;
-        }
+    return calculated_size;
+}
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-                << eprosima::fastcdr::MemberId(3) << data.extra_data()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+        << eprosima::fastcdr::MemberId(3) << data.extra_data()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                CO2FootprintImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        CO2FootprintImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1269,24 +1269,24 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-        }
+}
 
-    } // namespace fastcdr
+}     // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
+++ b/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
@@ -32,74 +32,77 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-namespace fastcdr {
+    namespace fastcdr {
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const TaskIdImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const TaskIdImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.problem_id(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.iteration_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.problem_id(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.iteration_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.problem_id()
-        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        TaskIdImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.problem_id()
+                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                TaskIdImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.problem_id();
-                                            break;
+                    case 0:
+                        dcdr >> data.problem_id();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.iteration_id();
-                                            break;
+                    case 1:
+                        dcdr >> data.iteration_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -107,120 +110,122 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.problem_id();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.problem_id();
 
-                        scdr << data.iteration_id();
+            scdr << data.iteration_id();
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeStatusImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeStatusImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.node_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.task_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.error_code(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.error_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.node_name(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.node_status(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.task_status(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.error_code(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.node_status()
-        << eprosima::fastcdr::MemberId(1) << data.task_status()
-        << eprosima::fastcdr::MemberId(2) << data.error_code()
-        << eprosima::fastcdr::MemberId(3) << data.error_description()
-        << eprosima::fastcdr::MemberId(4) << data.node_name()
-        << eprosima::fastcdr::MemberId(5) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.error_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeStatusImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.node_name(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.node_status()
+                << eprosima::fastcdr::MemberId(1) << data.task_status()
+                << eprosima::fastcdr::MemberId(2) << data.error_code()
+                << eprosima::fastcdr::MemberId(3) << data.error_description()
+                << eprosima::fastcdr::MemberId(4) << data.node_name()
+                << eprosima::fastcdr::MemberId(5) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeStatusImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.node_status();
-                                            break;
+                    case 0:
+                        dcdr >> data.node_status();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.task_status();
-                                            break;
+                    case 1:
+                        dcdr >> data.task_status();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.error_code();
-                                            break;
+                    case 2:
+                        dcdr >> data.error_code();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.error_description();
-                                            break;
+                    case 3:
+                        dcdr >> data.error_description();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.node_name();
-                                            break;
+                    case 4:
+                        dcdr >> data.node_name();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 5:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -228,118 +233,118 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.node_name();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.node_name();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeControlImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-
-
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeControlImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.cmd_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.cmd_task(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.target_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.source_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.cmd_node(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.cmd_task(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.target_node(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-        << eprosima::fastcdr::MemberId(2) << data.target_node()
-        << eprosima::fastcdr::MemberId(3) << data.source_node()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.source_node(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeControlImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+                << eprosima::fastcdr::MemberId(2) << data.target_node()
+                << eprosima::fastcdr::MemberId(3) << data.source_node()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeControlImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.cmd_node();
-                                            break;
+                    case 0:
+                        dcdr >> data.cmd_node();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.cmd_task();
-                                            break;
+                    case 1:
+                        dcdr >> data.cmd_task();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.target_node();
-                                            break;
+                    case 2:
+                        dcdr >> data.target_node();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.source_node();
-                                            break;
+                    case 3:
+                        dcdr >> data.source_node();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -347,196 +352,198 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.source_node();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.source_node();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const UserInputImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const UserInputImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.modality(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.problem_short_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.problem_definition(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.inputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.outputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.minimum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.maximum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.optimize_carbon_footprint_manual(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.previous_iteration(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                data.optimize_carbon_footprint_auto(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                data.desired_carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                data.geo_location_continent(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                data.geo_location_region(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.modality(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.problem_short_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.problem_definition(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.modality()
-        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-        << eprosima::fastcdr::MemberId(3) << data.inputs()
-        << eprosima::fastcdr::MemberId(4) << data.outputs()
-        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-        << eprosima::fastcdr::MemberId(13) << data.extra_data()
-        << eprosima::fastcdr::MemberId(14) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.inputs(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        UserInputImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.outputs(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.minimum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.maximum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.optimize_carbon_footprint_manual(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.previous_iteration(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                            data.optimize_carbon_footprint_auto(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                            data.desired_carbon_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                            data.geo_location_continent(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                            data.geo_location_region(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.modality()
+                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+                << eprosima::fastcdr::MemberId(3) << data.inputs()
+                << eprosima::fastcdr::MemberId(4) << data.outputs()
+                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+                << eprosima::fastcdr::MemberId(13) << data.extra_data()
+                << eprosima::fastcdr::MemberId(14) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                UserInputImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.modality();
-                                            break;
+                    case 0:
+                        dcdr >> data.modality();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.problem_short_description();
-                                            break;
+                    case 1:
+                        dcdr >> data.problem_short_description();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.problem_definition();
-                                            break;
+                    case 2:
+                        dcdr >> data.problem_definition();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.inputs();
-                                            break;
+                    case 3:
+                        dcdr >> data.inputs();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.outputs();
-                                            break;
+                    case 4:
+                        dcdr >> data.outputs();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.minimum_samples();
-                                            break;
+                    case 5:
+                        dcdr >> data.minimum_samples();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.maximum_samples();
-                                            break;
+                    case 6:
+                        dcdr >> data.maximum_samples();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.optimize_carbon_footprint_manual();
-                                            break;
+                    case 7:
+                        dcdr >> data.optimize_carbon_footprint_manual();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.previous_iteration();
-                                            break;
+                    case 8:
+                        dcdr >> data.previous_iteration();
+                        break;
 
-                                        case 9:
-                                                dcdr >> data.optimize_carbon_footprint_auto();
-                                            break;
+                    case 9:
+                        dcdr >> data.optimize_carbon_footprint_auto();
+                        break;
 
-                                        case 10:
-                                                dcdr >> data.desired_carbon_footprint();
-                                            break;
+                    case 10:
+                        dcdr >> data.desired_carbon_footprint();
+                        break;
 
-                                        case 11:
-                                                dcdr >> data.geo_location_continent();
-                                            break;
+                    case 11:
+                        dcdr >> data.geo_location_continent();
+                        break;
 
-                                        case 12:
-                                                dcdr >> data.geo_location_region();
-                                            break;
+                    case 12:
+                        dcdr >> data.geo_location_region();
+                        break;
 
-                                        case 13:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 13:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 14:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 14:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -544,106 +551,108 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelMetadataImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelMetadataImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.keywords(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.ml_model_metadata(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.keywords(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.ml_model_metadata(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.extra_data(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.keywords()
-        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-        << eprosima::fastcdr::MemberId(2) << data.extra_data()
-        << eprosima::fastcdr::MemberId(3) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.task_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelMetadataImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.keywords()
+                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+                << eprosima::fastcdr::MemberId(2) << data.extra_data()
+                << eprosima::fastcdr::MemberId(3) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelMetadataImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.keywords();
-                                            break;
+                    case 0:
+                        dcdr >> data.keywords();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.ml_model_metadata();
-                                            break;
+                    case 1:
+                        dcdr >> data.ml_model_metadata();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 2:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 3:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -651,98 +660,100 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const AppRequirementsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const AppRequirementsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.app_requirements(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.app_requirements(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.task_id(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-        << eprosima::fastcdr::MemberId(1) << data.extra_data()
-        << eprosima::fastcdr::MemberId(2) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        AppRequirementsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+                << eprosima::fastcdr::MemberId(1) << data.extra_data()
+                << eprosima::fastcdr::MemberId(2) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                AppRequirementsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.app_requirements();
-                                            break;
+                    case 0:
+                        dcdr >> data.app_requirements();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 1:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 2:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -750,106 +761,108 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWConstraintsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWConstraintsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.max_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.hardware_required(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.max_memory_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.hardware_required(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.extra_data(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
-        << eprosima::fastcdr::MemberId(2) << data.extra_data()
-        << eprosima::fastcdr::MemberId(3) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.task_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWConstraintsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+                << eprosima::fastcdr::MemberId(2) << data.extra_data()
+                << eprosima::fastcdr::MemberId(3) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWConstraintsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.max_memory_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.max_memory_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.hardware_required();
-                                            break;
+                    case 1:
+                        dcdr >> data.hardware_required();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 2:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 3:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -857,146 +870,148 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.model_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.raw_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.model_properties_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.model_properties(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.input_batch(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.target_latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.model_path(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.raw_model(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.model_path()
-        << eprosima::fastcdr::MemberId(1) << data.model()
-        << eprosima::fastcdr::MemberId(2) << data.raw_model()
-        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-        << eprosima::fastcdr::MemberId(4) << data.model_properties()
-        << eprosima::fastcdr::MemberId(5) << data.input_batch()
-        << eprosima::fastcdr::MemberId(6) << data.target_latency()
-        << eprosima::fastcdr::MemberId(7) << data.extra_data()
-        << eprosima::fastcdr::MemberId(8) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.model_properties_path(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.model_properties(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.input_batch(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.target_latency(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.model_path()
+                << eprosima::fastcdr::MemberId(1) << data.model()
+                << eprosima::fastcdr::MemberId(2) << data.raw_model()
+                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+                << eprosima::fastcdr::MemberId(4) << data.model_properties()
+                << eprosima::fastcdr::MemberId(5) << data.input_batch()
+                << eprosima::fastcdr::MemberId(6) << data.target_latency()
+                << eprosima::fastcdr::MemberId(7) << data.extra_data()
+                << eprosima::fastcdr::MemberId(8) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.model_path();
-                                            break;
+                    case 0:
+                        dcdr >> data.model_path();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.model();
-                                            break;
+                    case 1:
+                        dcdr >> data.model();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.raw_model();
-                                            break;
+                    case 2:
+                        dcdr >> data.raw_model();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.model_properties_path();
-                                            break;
+                    case 3:
+                        dcdr >> data.model_properties_path();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.model_properties();
-                                            break;
+                    case 4:
+                        dcdr >> data.model_properties();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.input_batch();
-                                            break;
+                    case 5:
+                        dcdr >> data.input_batch();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.target_latency();
-                                            break;
+                    case 6:
+                        dcdr >> data.target_latency();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 7:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 8:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1004,130 +1019,132 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWResourceImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWResourceImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.hw_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.power_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.memory_footprint_of_ml_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.max_hw_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.hw_description(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.power_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.latency(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.hw_description()
-        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.latency()
-        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-        << eprosima::fastcdr::MemberId(5) << data.extra_data()
-        << eprosima::fastcdr::MemberId(6) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.memory_footprint_of_ml_model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWResourceImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.max_hw_memory_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.hw_description()
+                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.latency()
+                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+                << eprosima::fastcdr::MemberId(5) << data.extra_data()
+                << eprosima::fastcdr::MemberId(6) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWResourceImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.hw_description();
-                                            break;
+                    case 0:
+                        dcdr >> data.hw_description();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.power_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.power_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.latency();
-                                            break;
+                    case 2:
+                        dcdr >> data.latency();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.memory_footprint_of_ml_model();
-                                            break;
+                    case 3:
+                        dcdr >> data.memory_footprint_of_ml_model();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.max_hw_memory_footprint();
-                                            break;
+                    case 4:
+                        dcdr >> data.max_hw_memory_footprint();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 5:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 6:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1135,114 +1152,116 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const CO2FootprintImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const CO2FootprintImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.energy_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.carbon_intensity(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.carbon_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.energy_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.carbon_intensity(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-        << eprosima::fastcdr::MemberId(3) << data.extra_data()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        CO2FootprintImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+                << eprosima::fastcdr::MemberId(3) << data.extra_data()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                CO2FootprintImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.carbon_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.carbon_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.energy_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.energy_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.carbon_intensity();
-                                            break;
+                    case 2:
+                        dcdr >> data.carbon_intensity();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 3:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1250,26 +1269,24 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
-
-
-} // namespace fastcdr
+    } // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.cxx
+++ b/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.cxx
@@ -128,8 +128,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,7 +184,8 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -309,8 +310,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -365,7 +366,8 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -392,8 +394,6 @@ void NodeStatusImplPubSubType::register_type_object_representation()
 {
     register_NodeStatusImpl_type_identifier(type_identifiers_);
 }
-
-
 
 NodeControlImplPubSubType::NodeControlImplPubSubType()
 {
@@ -492,8 +492,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,7 +548,8 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -673,8 +674,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -729,7 +730,8 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -854,8 +856,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -910,7 +912,8 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -1035,8 +1038,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1091,7 +1094,8 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1216,8 +1220,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1272,7 +1276,8 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1397,8 +1402,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1453,7 +1458,8 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1578,8 +1584,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1634,7 +1640,8 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1759,8 +1766,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1815,7 +1822,8 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1842,7 +1850,6 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
-
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.cxx
+++ b/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.cxx
@@ -128,8 +128,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,8 +184,7 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -310,8 +309,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -366,8 +365,7 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -394,6 +392,8 @@ void NodeStatusImplPubSubType::register_type_object_representation()
 {
     register_NodeStatusImpl_type_identifier(type_identifiers_);
 }
+
+
 
 NodeControlImplPubSubType::NodeControlImplPubSubType()
 {
@@ -492,8 +492,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,8 +548,7 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -674,8 +673,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -730,8 +729,7 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -856,8 +854,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -912,8 +910,7 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -1038,8 +1035,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1094,8 +1091,7 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1220,8 +1216,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1276,8 +1272,7 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1402,8 +1397,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1458,8 +1453,7 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1584,8 +1578,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1640,8 +1634,7 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1766,8 +1759,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1822,8 +1815,7 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1850,6 +1842,7 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
+
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.cxx
@@ -43,8 +43,7 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -54,204 +53,151 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
-                        ann_custom_Status,
-                        type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
-                        detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
-                            member_ann_builtin_NODE_ERROR,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
-                            member_ann_builtin_NODE_IDLE,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
-                            member_ann_builtin_NODE_RUNNING,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
-                            flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_Status, header_Status,
-            literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
+                literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
-                type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "Status already registered in TypeObjectRegistry for a different type.");
+                "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_TaskStatus_type_identifier(
+}void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus =
-                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
-                        ann_custom_TaskStatus,
-                        type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
-            common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
-                            member_ann_builtin_TASK_WAITING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
-                            member_ann_builtin_TASK_ERROR,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
-                            member_ann_builtin_TASK_RUNNING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
-                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_TaskStatus, header_TaskStatus,
-            literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
+                literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
-                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_ErrorCode_type_identifier(
+}void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -261,72 +207,55 @@ void register_ErrorCode_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
-                        ann_custom_ErrorCode,
-                        type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
-                        detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR =
-                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
-                            member_ann_builtin_NO_ERROR,
-                            ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
-                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_ErrorCode, header_ErrorCode,
-            literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
+                literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
-                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
-                        ann_custom_TaskIdImpl,
-                        type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -334,8 +263,7 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -344,37 +272,28 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
-                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_problem_id,
-                                                              common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
-                            member_ann_builtin_problem_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
-                            detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -383,44 +302,32 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
-                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_iteration_id,
-                                                                common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
-                            member_ann_builtin_iteration_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
-                common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
-                        header_TaskIdImpl,
-                        member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
-                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -428,19 +335,16 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -448,119 +352,91 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-                ::register_Status_type_identifier(type_ids_node_status);
+            ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
-                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_node_status,
-                                                               common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
-                            member_ann_builtin_node_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
-                            detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-                ::register_TaskStatus_type_identifier(type_ids_task_status);
+            ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
-                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_task_status,
-                                                               common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
-                            member_ann_builtin_task_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
-                            detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-                ::register_ErrorCode_type_identifier(type_ids_error_code);
+            ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
-                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_error_code,
-                                                              common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
-                            member_ann_builtin_error_code,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
-                            detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -573,41 +449,32 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_error_description,
-                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_error_description,
-                                                                 common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
-                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
-                common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -620,23 +487,18 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
-                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_node_name,
-                                                             common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -647,46 +509,34 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
-                    hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
-                                min_node_name,
-                                max_node_name,
-                                hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
-                            member_ann_builtin_node_name,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
-                            detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -700,44 +550,33 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
-                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -747,101 +586,74 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
-                        ann_custom_CmdNode,
-                        type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
-                        detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
-                            member_ann_builtin_NO_CMD_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
-                            member_ann_builtin_START_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
-                            member_ann_builtin_STOP_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
-                            member_ann_builtin_RESET_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdNode, header_CmdNode,
-            literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
+                literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
-                type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdNode already registered in TypeObjectRegistry for a different type.");
+                "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_CmdTask_type_identifier(
+}void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -851,197 +663,149 @@ void register_CmdTask_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
-                        ann_custom_CmdTask,
-                        type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
-                        detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
-                            member_ann_builtin_NO_CMD_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
-                            member_ann_builtin_STOP_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
-                            member_ann_builtin_RESET_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
-                            member_ann_builtin_PREEMPT_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdTask, header_CmdTask,
-            literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
+                literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
-                type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdTask already registered in TypeObjectRegistry for a different type.");
+                "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl =
-                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-                ::register_CmdNode_type_identifier(type_ids_cmd_node);
+            ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
-                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_node,
-                                                            common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
-                            member_ann_builtin_cmd_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
-                            detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-                ::register_CmdTask_type_identifier(type_ids_cmd_task);
+            ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
-                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_task,
-                                                            common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
-                            member_ann_builtin_cmd_task,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
-                            detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -1054,41 +818,32 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
-                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_target_node,
-                                                               common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
-                            member_ann_builtin_target_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
-                            detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -1101,23 +856,18 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
-                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_source_node,
-                                                               common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -1128,44 +878,34 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
-                    hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
-                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
-                            member_ann_builtin_source_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
-                            detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1179,37 +919,27 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
-                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -1217,19 +947,16 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -1237,8 +964,7 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -1251,41 +977,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
-                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_modality,
-                                                            common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
-                            member_ann_builtin_modality,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
-                            detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1298,42 +1015,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
-                                                                     member_id_problem_short_description,
-                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                         type_ids_problem_short_description,
-                                                                         common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
-                name_problem_short_description, member_ann_builtin_problem_short_description,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
-                common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1346,48 +1053,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_problem_definition,
-                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_problem_definition,
-                                                                  common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
-                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
-                common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1400,15 +1097,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_inputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1420,34 +1114,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
-                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                          type_ids_inputs,
-                                                          common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1456,26 +1140,21 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
-                            member_ann_builtin_inputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
-                            detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1488,15 +1167,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_outputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1508,34 +1184,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
-                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_outputs,
-                                                           common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1544,19 +1210,15 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
-                            member_ann_builtin_outputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
-                            detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1565,36 +1227,28 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_minimum_samples,
-                                                               common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1603,36 +1257,28 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_maximum_samples,
-                                                               common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1641,42 +1287,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
-                                                                            member_id_optimize_carbon_footprint_manual,
-                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                type_ids_optimize_carbon_footprint_manual,
-                                                                                common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
-                            member_ann_builtin_optimize_carbon_footprint_manual,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
-                            detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1685,37 +1317,28 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_previous_iteration,
-                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_previous_iteration,
-                                                                  common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
-                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
-                common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1724,40 +1347,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
-                                                                          member_id_optimize_carbon_footprint_auto,
-                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                              type_ids_optimize_carbon_footprint_auto,
-                                                                              common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
-                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
-                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1766,38 +1377,28 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                    member_id_desired_carbon_footprint,
-                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                        type_ids_desired_carbon_footprint,
-                                                                        common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1810,41 +1411,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
-                                                                  member_id_geo_location_continent,
-                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                      type_ids_geo_location_continent,
-                                                                      common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1857,48 +1449,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
-                                                               member_id_geo_location_region,
-                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                   type_ids_geo_location_region,
-                                                                   common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1907,85 +1489,65 @@ void register_UserInputImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1999,37 +1561,27 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
-                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -2037,37 +1589,30 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
-            type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -2080,15 +1625,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_keywords,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2100,63 +1642,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
-                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_keywords,
-                                                            common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
-                            member_ann_builtin_keywords,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
-                            detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -2169,15 +1695,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_ml_model_metadata,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2189,63 +1712,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_ml_model_metadata,
-                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_ml_model_metadata,
-                                                                 common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
-                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
-                common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2254,85 +1761,65 @@ void register_MLModelMetadataImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2346,37 +1833,27 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
-                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -2384,37 +1861,30 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
-            type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -2427,15 +1897,12 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_app_requirements,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2447,62 +1914,47 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_app_requirements,
-                                                                common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
-                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
-                common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2511,85 +1963,65 @@ void register_AppRequirementsImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2603,37 +2035,27 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
-                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2641,30 +2063,24 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
-            type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2673,44 +2089,104 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                member_id_max_memory_footprint,
-                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                    type_ids_max_memory_footprint,
-                                                                    common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
+        }
+        {
+            TypeIdentifierPair type_ids_hardware_required;
+            ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_hardware_required =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
+            {
+                return_code_hardware_required =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "anonymous_string_unbounded", type_ids_hardware_required);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
+                {
+                    {
+                        SBound bound = 0;
+                        StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                                TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                                "anonymous_string_unbounded", type_ids_hardware_required))
+                        {
+                            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                        }
+                    }
+                }
+                bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_COMPLETE;
+                if (TK_NONE == type_ids_hardware_required.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                {
+                    SBound bound = 0;
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_hardware_required = 0x00000001;
+            bool common_hardware_required_ec {false};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
+            if (!common_hardware_required_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_hardware_required = "hardware_required";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
+            ann_custom_HWConstraintsImpl.reset();
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
+            TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2719,85 +2195,65 @@ void register_HWConstraintsImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
-            MemberId member_id_extra_data = 0x00000001;
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
-            MemberId member_id_task_id = 0x00000002;
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2811,37 +2267,27 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
-                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2849,19 +2295,16 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2869,8 +2312,7 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2883,41 +2325,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
-                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_model_path,
-                                                              common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
-                            member_ann_builtin_model_path,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
-                            detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2930,19 +2363,15 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
-                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                         type_ids_model,
-                                                         common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2951,26 +2380,21 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
-                            member_ann_builtin_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model =
-                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_raw_model);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2979,70 +2403,54 @@ void register_MLModelImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_raw_model,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_raw_model.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
-                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_raw_model,
-                                                             common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
-                            member_ann_builtin_raw_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
-                            detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -3055,41 +2463,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
-                                                                 member_id_model_properties_path,
-                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                     type_ids_model_properties_path,
-                                                                     common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -3102,47 +2501,38 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_model_properties,
-                                                                common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -3155,15 +2545,12 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_input_batch,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3175,56 +2562,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
-                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_input_batch,
-                                                               common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
-                            member_ann_builtin_input_batch,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
-                            detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -3233,43 +2605,34 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_target_latency,
-                                                              common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
-                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
-                common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3278,85 +2641,65 @@ void register_MLModelImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3370,37 +2713,27 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
-                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -3408,19 +2741,16 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -3428,8 +2758,7 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -3442,40 +2771,32 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_hw_description,
-                                                              common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
-                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
-                common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -3484,37 +2805,28 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_power_consumption,
-                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_power_consumption,
-                                                                 common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -3523,15 +2835,11 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
-                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_latency,
-                                                           common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -3540,19 +2848,15 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
-                            member_ann_builtin_latency,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
-                            detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -3561,38 +2865,28 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
-                                                                        member_id_memory_footprint_of_ml_model,
-                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                            type_ids_memory_footprint_of_ml_model,
-                                                                            common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
-                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
-                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -3601,45 +2895,34 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                   member_id_max_hw_memory_footprint,
-                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                       type_ids_max_hw_memory_footprint,
-                                                                       common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3648,85 +2931,65 @@ void register_HWResourceImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3740,37 +3003,27 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
-                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3778,29 +3031,24 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3809,36 +3057,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_footprint,
-                                                                common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3847,37 +3087,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_energy_consumption,
-                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_energy_consumption,
-                                                                  common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3886,43 +3117,34 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_intensity,
-                                                                common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3931,85 +3153,65 @@ void register_CO2FootprintImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -4023,33 +3225,25 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
-                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+

--- a/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.cxx
@@ -43,7 +43,8 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -53,151 +54,204 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
+                        ann_custom_Status,
+                        type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
+                        detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
+                            member_ann_builtin_NODE_ERROR,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
+                            member_ann_builtin_NODE_IDLE,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
+                            member_ann_builtin_NODE_RUNNING,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
+                            flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
-                literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_Status, header_Status,
+            literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
+                type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "Status already registered in TypeObjectRegistry for a different type.");
+                    "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_TaskStatus_type_identifier(
+}
+
+void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus =
+                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
+                        ann_custom_TaskStatus,
+                        type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
+            common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
+                            member_ann_builtin_TASK_WAITING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
+                            member_ann_builtin_TASK_ERROR,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
+                            member_ann_builtin_TASK_RUNNING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
+                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
-                literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_TaskStatus, header_TaskStatus,
+            literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
+                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_ErrorCode_type_identifier(
+}
+
+void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -207,55 +261,72 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
+                        ann_custom_ErrorCode,
+                        type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
+                        detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR =
+                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
+                            member_ann_builtin_NO_ERROR,
+                            ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
+                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
-                literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_ErrorCode, header_ErrorCode,
+            literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
+                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
+                        ann_custom_TaskIdImpl,
+                        type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -263,7 +334,8 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -272,28 +344,37 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
+                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_problem_id,
+                                                              common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
+                            member_ann_builtin_problem_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
+                            detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -302,32 +383,44 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
+                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_iteration_id,
+                                                                common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
+                            member_ann_builtin_iteration_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
+                common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
+                        header_TaskIdImpl,
+                        member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
+                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -335,16 +428,19 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -352,91 +448,119 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-            ::register_Status_type_identifier(type_ids_node_status);
+                ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
+                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_node_status,
+                                                               common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
+                            member_ann_builtin_node_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
+                            detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-            ::register_TaskStatus_type_identifier(type_ids_task_status);
+                ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
+                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_task_status,
+                                                               common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
+                            member_ann_builtin_task_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
+                            detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-            ::register_ErrorCode_type_identifier(type_ids_error_code);
+                ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
+                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_error_code,
+                                                              common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
+                            member_ann_builtin_error_code,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
+                            detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -449,32 +573,41 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_error_description,
+                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_error_description,
+                                                                 common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
+                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
+                common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -487,18 +620,23 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
+                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_node_name,
+                                                             common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -509,34 +647,46 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
+                    hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
+                                min_node_name,
+                                max_node_name,
+                                hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
+                            member_ann_builtin_node_name,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
+                            detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -550,33 +700,44 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
+                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -586,74 +747,101 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
+                        ann_custom_CmdNode,
+                        type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
+                        detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
+                            member_ann_builtin_NO_CMD_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
+                            member_ann_builtin_START_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
+                            member_ann_builtin_STOP_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
+                            member_ann_builtin_RESET_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
-                literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdNode, header_CmdNode,
+            literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
+                type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdNode already registered in TypeObjectRegistry for a different type.");
+                    "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_CmdTask_type_identifier(
+}
+
+void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -663,149 +851,197 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
+                        ann_custom_CmdTask,
+                        type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
+                        detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
+                            member_ann_builtin_NO_CMD_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
+                            member_ann_builtin_STOP_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
+                            member_ann_builtin_RESET_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
+                            member_ann_builtin_PREEMPT_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
-                literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdTask, header_CmdTask,
+            literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
+                type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdTask already registered in TypeObjectRegistry for a different type.");
+                    "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl =
+                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-            ::register_CmdNode_type_identifier(type_ids_cmd_node);
+                ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
+                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_node,
+                                                            common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
+                            member_ann_builtin_cmd_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
+                            detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-            ::register_CmdTask_type_identifier(type_ids_cmd_task);
+                ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
+                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_task,
+                                                            common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
+                            member_ann_builtin_cmd_task,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
+                            detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -818,32 +1054,41 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
+                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_target_node,
+                                                               common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
+                            member_ann_builtin_target_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
+                            detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -856,18 +1101,23 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
+                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_source_node,
+                                                               common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -878,34 +1128,44 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
+                    hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
+                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
+                            member_ann_builtin_source_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
+                            detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -919,27 +1179,37 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
+                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -947,16 +1217,19 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -964,7 +1237,8 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -977,32 +1251,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
+                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_modality,
+                                                            common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
+                            member_ann_builtin_modality,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
+                            detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1015,32 +1298,42 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
+                                                                     member_id_problem_short_description,
+                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                         type_ids_problem_short_description,
+                                                                         common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
+                name_problem_short_description, member_ann_builtin_problem_short_description,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
+                common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1053,38 +1346,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_problem_definition,
+                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_problem_definition,
+                                                                  common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
+                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
+                common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1097,12 +1400,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_inputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1114,24 +1420,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
+                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                          type_ids_inputs,
+                                                          common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1140,21 +1456,26 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
+                            member_ann_builtin_inputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
+                            detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1167,12 +1488,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_outputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1184,24 +1508,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
+                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_outputs,
+                                                           common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1210,15 +1544,19 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
+                            member_ann_builtin_outputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
+                            detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1227,28 +1565,36 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_minimum_samples,
+                                                               common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1257,28 +1603,36 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_maximum_samples,
+                                                               common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1287,28 +1641,42 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
+                                                                            member_id_optimize_carbon_footprint_manual,
+                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                type_ids_optimize_carbon_footprint_manual,
+                                                                                common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
+                            member_ann_builtin_optimize_carbon_footprint_manual,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
+                            detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1317,28 +1685,37 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_previous_iteration,
+                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_previous_iteration,
+                                                                  common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
+                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
+                common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1347,28 +1724,40 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
+                                                                          member_id_optimize_carbon_footprint_auto,
+                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                              type_ids_optimize_carbon_footprint_auto,
+                                                                              common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
+                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
+                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1377,28 +1766,38 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                    member_id_desired_carbon_footprint,
+                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                        type_ids_desired_carbon_footprint,
+                                                                        common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1411,32 +1810,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
+                                                                  member_id_geo_location_continent,
+                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                      type_ids_geo_location_continent,
+                                                                      common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1449,38 +1857,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
+                                                               member_id_geo_location_region,
+                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                   type_ids_geo_location_region,
+                                                                   common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1490,7 +1908,9 @@ void register_UserInputImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1502,52 +1922,70 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1561,27 +1999,37 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
+                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -1589,30 +2037,37 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
+            type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -1625,12 +2080,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_keywords,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1642,47 +2100,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
+                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_keywords,
+                                                            common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
+                            member_ann_builtin_keywords,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
+                            detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -1695,12 +2169,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_ml_model_metadata,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1712,47 +2189,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_ml_model_metadata,
+                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_ml_model_metadata,
+                                                                 common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
+                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
+                common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1762,7 +2255,9 @@ void register_MLModelMetadataImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1774,52 +2269,70 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1833,27 +2346,37 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
+                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -1861,30 +2384,37 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
+            type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -1897,12 +2427,15 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_app_requirements,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1914,47 +2447,62 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_app_requirements,
+                                                                common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
+                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
+                common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1964,7 +2512,9 @@ void register_AppRequirementsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1976,52 +2526,70 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2035,27 +2603,37 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
+                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2063,24 +2641,30 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
+            type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2089,34 +2673,44 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                member_id_max_memory_footprint,
+                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                    type_ids_max_memory_footprint,
+                                                                    common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_hardware_required;
             ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hardware_required =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
             {
                 return_code_hardware_required =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_hardware_required);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
@@ -2129,12 +2723,15 @@ void register_HWConstraintsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_hardware_required))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_hardware_required,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2146,47 +2743,63 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_hardware_required = 0x00000001;
             bool common_hardware_required_ec {false};
-            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_hardware_required,
+                                                             member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_hardware_required,
+                                                                 common_hardware_required_ec))};
             if (!common_hardware_required_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure hardware_required member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hardware_required = "hardware_required";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(
+                name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(
+                common_hardware_required, detail_hardware_required);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2196,7 +2809,9 @@ void register_HWConstraintsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2208,52 +2823,70 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2267,27 +2900,37 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
+                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2295,16 +2938,19 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2312,7 +2958,8 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2325,32 +2972,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
+                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_model_path,
+                                                              common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
+                            member_ann_builtin_model_path,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
+                            detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2363,15 +3019,19 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
+                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                         type_ids_model,
+                                                         common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2380,21 +3040,26 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
+                            member_ann_builtin_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model =
+                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2404,7 +3069,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_raw_model,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2416,41 +3083,55 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
+                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_raw_model,
+                                                             common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
+                            member_ann_builtin_raw_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
+                            detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -2463,32 +3144,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
+                                                                 member_id_model_properties_path,
+                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                     type_ids_model_properties_path,
+                                                                     common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -2501,38 +3191,47 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_model_properties,
+                                                                common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -2545,12 +3244,15 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_input_batch,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2562,41 +3264,56 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
+                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_input_batch,
+                                                               common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
+                            member_ann_builtin_input_batch,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
+                            detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -2605,34 +3322,43 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_target_latency,
+                                                              common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
+                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
+                common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2642,7 +3368,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2654,52 +3382,70 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2713,27 +3459,37 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
+                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -2741,16 +3497,19 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -2758,7 +3517,8 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -2771,32 +3531,40 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_hw_description,
+                                                              common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
+                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
+                common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -2805,28 +3573,37 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_power_consumption,
+                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_power_consumption,
+                                                                 common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -2835,11 +3612,15 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
+                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_latency,
+                                                           common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -2848,15 +3629,19 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
+                            member_ann_builtin_latency,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
+                            detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -2865,28 +3650,38 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
+                                                                        member_id_memory_footprint_of_ml_model,
+                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                            type_ids_memory_footprint_of_ml_model,
+                                                                            common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
+                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
+                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -2895,34 +3690,45 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                   member_id_max_hw_memory_footprint,
+                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                       type_ids_max_hw_memory_footprint,
+                                                                       common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2932,7 +3738,9 @@ void register_HWResourceImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2944,52 +3752,70 @@ void register_HWResourceImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3003,27 +3829,37 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
+                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3031,24 +3867,29 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3057,28 +3898,36 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_footprint,
+                                                                common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3087,28 +3936,37 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_energy_consumption,
+                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_energy_consumption,
+                                                                  common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3117,34 +3975,43 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_intensity,
+                                                                common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3154,7 +4021,9 @@ void register_CO2FootprintImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3166,52 +4035,70 @@ void register_CO2FootprintImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3225,25 +4112,33 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
+                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-

--- a/sustainml_cpp/test/blackbox/common/BlackboxTests.hpp
+++ b/sustainml_cpp/test/blackbox/common/BlackboxTests.hpp
@@ -36,7 +36,7 @@
 #include "../api/ManagedNode.hpp"
 #include "../api/TaskInjector.hpp"
 
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 #include <types/typesImplPubSubTypes.hpp>
 
 #include <algorithm>

--- a/sustainml_cpp/test/blackbox/helpers/data_generators.cpp
+++ b/sustainml_cpp/test/blackbox/helpers/data_generators.cpp
@@ -83,6 +83,7 @@ std::list<HWConstraintsImpl> default_hwconstraints_task_generator(
                 hw_cons.task_id().problem_id(index);
                 hw_cons.task_id().iteration_id(1);
                 hw_cons.max_memory_footprint(index);
+                hw_cons.hardware_required(std::vector<std::string>{"PIM_AI_1chip"});
                 ++index;
                 return hw_cons;
             });

--- a/sustainml_cpp/utils/instructions/README.md
+++ b/sustainml_cpp/utils/instructions/README.md
@@ -10,7 +10,7 @@ The next steps needs to be followed to do so while trying to regenerate SustainM
 
     `cd sustainml_cpp/utils/scripts && bash update_types.sh`
 
-1. Manually introduce the `sustainml_cpp/src/cpp/types/typesImpl.h` changes in `sustainml_cpp/include/sustainml_cpp/types/types.h`, and applying these changes:
+1. Manually introduce the `sustainml_cpp/src/cpp/types/typesImpl.hpp` changes in `sustainml_cpp/include/sustainml_cpp/types/types.hpp`, and applying these changes:
     1. Copy the complete class `ClassNameImpl` in the _types.h_ file
     1. Rename it as `ClassName` (remove `Impl` suffix), as well as all its usage in its methods and comments.
     1. Introduce the following line right after the _public_ declaration:

--- a/sustainml_cpp/utils/scripts/update_types.sh
+++ b/sustainml_cpp/utils/scripts/update_types.sh
@@ -62,9 +62,9 @@ for idl_file in "${idl_files[@]}"; do
     echo $od_src
 
     if [[ -z "$od_src" ]]; then
-        fastddsgen -replace -typeobject "$file_from_gen"
+        fastddsgen -replace "$file_from_gen"
     else
-        fastddsgen -replace -typeobject -d $od_src "$file_from_gen"
+        fastddsgen -replace -d $od_src "$file_from_gen"
     fi
 
     if [[ $? != 0 ]]; then

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwconstraints.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwconstraints.rst
@@ -118,6 +118,7 @@ User is meant to implement the funcionality of the node within the ``test:callba
         # There is no need to specify node_status for the moment
         # as it will automatically be set to IDLE when the callback returns.
         hw_constraints.max_memory_footprint(100)
+        hw_constraints.hardware_required(["PIM_AI_1chip"])
 
     # Main workflow routine
     def run():

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwprovider.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/hwprovider.rst
@@ -111,7 +111,8 @@ User is meant to implement the funcionality of the node within the ``test:callba
             print(requirement)
 
         # HWConstraints
-        hw_constraint = hw_constraints.max_memory_footprint()
+        max_mem_footprint = hw_constraints.max_memory_footprint()
+        hw_required = hw_constraints.hardware_required()
 
         # Do processing...
 

--- a/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/mlmodelprovider.rst
+++ b/sustainml_docs/rst/developer_manual/architecture/backend/module_nodes/mlmodelprovider.rst
@@ -121,7 +121,8 @@ User is meant to implement the funcionality of the node within the ``test:callba
             print(requirement)
 
         # HWConstraints
-        hw_constraint = hw_constraints.max_memory_footprint()
+        max_mem_footprint = hw_constraints.max_memory_footprint()
+        hw_required = hw_constraints.hardware_required()
 
         # MLModel
         # Only in case of optimization (task_id.iteration_id() > 1)

--- a/sustainml_docs/rst/developer_manual/data_model/data_model.rst
+++ b/sustainml_docs/rst/developer_manual/data_model/data_model.rst
@@ -193,6 +193,7 @@ Hardware Constraints Type
 The ``HWConstraints`` represents the group of constraints defined (or not) by the user when describing the problem. It is the output from the ``Hardware Constraints Node``.
 
 * ``max_memory_footprint``: The maximum memory footprint allowed for the ML model.
+* ``hardware_required``: A sequence of hardware selected by the user to be taken into account by the framework.
 * ``extra_data``: A sequence of raw extra data for out-of-scope use cases.
 * ``task_id``: The identifier of the ML problem to solve.
 
@@ -203,6 +204,7 @@ The ``HWConstraints`` represents the group of constraints defined (or not) by th
     struct HWConstraints
     {
         unsigned long max_memory_footprint;
+        sequence<string> hardware_required;
         sequence<octet> extra_data;
         @key long task_id;
     };

--- a/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
+++ b/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
@@ -121,7 +121,9 @@ class Orchestrator:
 
         # Parse data into json
         max_value = node_data.max_memory_footprint()
-        json_output = {'max_memory_footprint': f'{max_value}<br>'}
+        required_hardware = node_data.hardware_required()
+        json_output = {'max_memory_footprint': f'{max_value}<br>',
+                       'hardware_required': f'{utils.string_std_vector(required_hardware)}<br>'}
         return json_output
 
     def get_ml_model_provider(self, task_id):

--- a/sustainml_modules/test/communication/types/typesImpl.hpp
+++ b/sustainml_modules/test/communication/types/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-               m_iteration_id == x.m_iteration_id);
+           m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,6 +209,7 @@ public:
         return m_problem_id;
     }
 
+
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -236,6 +237,8 @@ public:
     {
         return m_iteration_id;
     }
+
+
 
 private:
 
@@ -272,17 +275,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -309,17 +312,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -349,11 +352,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-               m_task_status == x.m_task_status &&
-               m_error_code == x.m_error_code &&
-               m_error_description == x.m_error_description &&
-               m_node_name == x.m_node_name &&
-               m_task_id == x.m_task_id);
+           m_task_status == x.m_task_status &&
+           m_error_code == x.m_error_code &&
+           m_error_description == x.m_error_description &&
+           m_node_name == x.m_node_name &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -394,6 +397,7 @@ public:
         return m_node_status;
     }
 
+
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -422,6 +426,7 @@ public:
         return m_task_status;
     }
 
+
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -449,6 +454,7 @@ public:
     {
         return m_error_code;
     }
+
 
     /*!
      * @brief This function copies the value in member error_description
@@ -488,6 +494,7 @@ public:
         return m_error_description;
     }
 
+
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -526,6 +533,7 @@ public:
         return m_node_name;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -563,6 +571,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -627,15 +637,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -661,15 +671,15 @@ public:
             const NodeControlImpl& x)
     {
 
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -698,10 +708,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-               m_cmd_task == x.m_cmd_task &&
-               m_target_node == x.m_target_node &&
-               m_source_node == x.m_source_node &&
-               m_task_id == x.m_task_id);
+           m_cmd_task == x.m_cmd_task &&
+           m_target_node == x.m_target_node &&
+           m_source_node == x.m_source_node &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -742,6 +752,7 @@ public:
         return m_cmd_node;
     }
 
+
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -769,6 +780,7 @@ public:
     {
         return m_cmd_task;
     }
+
 
     /*!
      * @brief This function copies the value in member target_node
@@ -808,6 +820,7 @@ public:
         return m_target_node;
     }
 
+
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -845,6 +858,7 @@ public:
     {
         return m_source_node;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -884,6 +898,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -922,35 +938,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -986,35 +1002,35 @@ public:
             const UserInputImpl& x)
     {
 
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1053,20 +1069,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-               m_problem_short_description == x.m_problem_short_description &&
-               m_problem_definition == x.m_problem_definition &&
-               m_inputs == x.m_inputs &&
-               m_outputs == x.m_outputs &&
-               m_minimum_samples == x.m_minimum_samples &&
-               m_maximum_samples == x.m_maximum_samples &&
-               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-               m_previous_iteration == x.m_previous_iteration &&
-               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-               m_geo_location_continent == x.m_geo_location_continent &&
-               m_geo_location_region == x.m_geo_location_region &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_problem_short_description == x.m_problem_short_description &&
+           m_problem_definition == x.m_problem_definition &&
+           m_inputs == x.m_inputs &&
+           m_outputs == x.m_outputs &&
+           m_minimum_samples == x.m_minimum_samples &&
+           m_maximum_samples == x.m_maximum_samples &&
+           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+           m_previous_iteration == x.m_previous_iteration &&
+           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+           m_geo_location_continent == x.m_geo_location_continent &&
+           m_geo_location_region == x.m_geo_location_region &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1117,6 +1133,7 @@ public:
         return m_modality;
     }
 
+
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1154,6 +1171,7 @@ public:
     {
         return m_problem_short_description;
     }
+
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1193,6 +1211,7 @@ public:
         return m_problem_definition;
     }
 
+
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1230,6 +1249,7 @@ public:
     {
         return m_inputs;
     }
+
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1269,6 +1289,7 @@ public:
         return m_outputs;
     }
 
+
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1296,6 +1317,7 @@ public:
     {
         return m_minimum_samples;
     }
+
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1325,6 +1347,7 @@ public:
         return m_maximum_samples;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1352,6 +1375,7 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
+
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1381,6 +1405,7 @@ public:
         return m_previous_iteration;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1409,6 +1434,7 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
+
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1436,6 +1462,7 @@ public:
     {
         return m_desired_carbon_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1475,6 +1502,7 @@ public:
         return m_geo_location_continent;
     }
 
+
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1512,6 +1540,7 @@ public:
     {
         return m_geo_location_region;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1551,6 +1580,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1588,6 +1618,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -1637,13 +1669,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1668,13 +1700,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1702,9 +1734,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-               m_ml_model_metadata == x.m_ml_model_metadata &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_ml_model_metadata == x.m_ml_model_metadata &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1755,6 +1787,7 @@ public:
         return m_keywords;
     }
 
+
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1792,6 +1825,7 @@ public:
     {
         return m_ml_model_metadata;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1831,6 +1865,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1869,6 +1904,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_keywords;
@@ -1906,11 +1943,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1934,11 +1971,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1965,8 +2002,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2017,6 +2054,7 @@ public:
         return m_app_requirements;
     }
 
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2054,6 +2092,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2093,6 +2132,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2129,11 +2170,13 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_task_id = x.m_task_id;
+                    m_extra_data = x.m_extra_data;
+
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2145,6 +2188,7 @@ public:
             HWConstraintsImpl&& x) noexcept
     {
         m_max_memory_footprint = x.m_max_memory_footprint;
+        m_hardware_required = std::move(x.m_hardware_required);
         m_extra_data = std::move(x.m_extra_data);
         m_task_id = std::move(x.m_task_id);
     }
@@ -2157,11 +2201,13 @@ public:
             const HWConstraintsImpl& x)
     {
 
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_task_id = x.m_task_id;
+                    m_extra_data = x.m_extra_data;
+
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2175,6 +2221,7 @@ public:
     {
 
         m_max_memory_footprint = x.m_max_memory_footprint;
+        m_hardware_required = std::move(x.m_hardware_required);
         m_extra_data = std::move(x.m_extra_data);
         m_task_id = std::move(x.m_task_id);
         return *this;
@@ -2188,8 +2235,9 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_hardware_required == x.m_hardware_required &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2230,6 +2278,46 @@ public:
         return m_max_memory_footprint;
     }
 
+
+    /*!
+     * @brief This function copies the value in member hardware_required
+     * @param _hardware_required New value to be copied in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            const std::vector<std::string>& _hardware_required)
+    {
+        m_hardware_required = _hardware_required;
+    }
+
+    /*!
+     * @brief This function moves the value in member hardware_required
+     * @param _hardware_required New value to be moved in member hardware_required
+     */
+    eProsima_user_DllExport void hardware_required(
+            std::vector<std::string>&& _hardware_required)
+    {
+        m_hardware_required = std::move(_hardware_required);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member hardware_required
+     * @return Constant reference to member hardware_required
+     */
+    eProsima_user_DllExport const std::vector<std::string>& hardware_required() const
+    {
+        return m_hardware_required;
+    }
+
+    /*!
+     * @brief This function returns a reference to member hardware_required
+     * @return Reference to member hardware_required
+     */
+    eProsima_user_DllExport std::vector<std::string>& hardware_required()
+    {
+        return m_hardware_required;
+    }
+
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2267,6 +2355,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2306,9 +2395,12 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     uint32_t m_max_memory_footprint{0};
+    std::vector<std::string> m_hardware_required;
     std::vector<uint8_t> m_extra_data;
     TaskIdImpl m_task_id;
 
@@ -2342,23 +2434,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2388,23 +2480,23 @@ public:
             const MLModelImpl& x)
     {
 
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2437,14 +2529,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-               m_model == x.m_model &&
-               m_raw_model == x.m_raw_model &&
-               m_model_properties_path == x.m_model_properties_path &&
-               m_model_properties == x.m_model_properties &&
-               m_input_batch == x.m_input_batch &&
-               m_target_latency == x.m_target_latency &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_model == x.m_model &&
+           m_raw_model == x.m_raw_model &&
+           m_model_properties_path == x.m_model_properties_path &&
+           m_model_properties == x.m_model_properties &&
+           m_input_batch == x.m_input_batch &&
+           m_target_latency == x.m_target_latency &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2495,6 +2587,7 @@ public:
         return m_model_path;
     }
 
+
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2532,6 +2625,7 @@ public:
     {
         return m_model;
     }
+
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2571,6 +2665,7 @@ public:
         return m_raw_model;
     }
 
+
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2608,6 +2703,7 @@ public:
     {
         return m_model_properties_path;
     }
+
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2647,6 +2743,7 @@ public:
         return m_model_properties;
     }
 
+
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2685,6 +2782,7 @@ public:
         return m_input_batch;
     }
 
+
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2712,6 +2810,7 @@ public:
     {
         return m_target_latency;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2751,6 +2850,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2788,6 +2888,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -2831,19 +2933,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2871,19 +2973,19 @@ public:
             const HWResourceImpl& x)
     {
 
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2914,12 +3016,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-               m_power_consumption == x.m_power_consumption &&
-               m_latency == x.m_latency &&
-               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_power_consumption == x.m_power_consumption &&
+           m_latency == x.m_latency &&
+           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2970,6 +3072,7 @@ public:
         return m_hw_description;
     }
 
+
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -2997,6 +3100,7 @@ public:
     {
         return m_power_consumption;
     }
+
 
     /*!
      * @brief This function sets a value in member latency
@@ -3026,6 +3130,7 @@ public:
         return m_latency;
     }
 
+
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3054,6 +3159,7 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
+
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3081,6 +3187,7 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3120,6 +3227,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3157,6 +3265,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -3198,15 +3308,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -3232,15 +3342,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3269,10 +3379,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-               m_energy_consumption == x.m_energy_consumption &&
-               m_carbon_intensity == x.m_carbon_intensity &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_energy_consumption == x.m_energy_consumption &&
+           m_carbon_intensity == x.m_carbon_intensity &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3313,6 +3423,7 @@ public:
         return m_carbon_footprint;
     }
 
+
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3341,6 +3452,7 @@ public:
         return m_energy_consumption;
     }
 
+
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3368,6 +3480,7 @@ public:
     {
         return m_carbon_intensity;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3407,6 +3520,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3444,6 +3558,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 

--- a/sustainml_modules/test/communication/types/typesImpl.hpp
+++ b/sustainml_modules/test/communication/types/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-                    m_problem_id = x.m_problem_id;
+        m_problem_id = x.m_problem_id;
 
-                    m_iteration_id = x.m_iteration_id;
+        m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-                    m_problem_id = x.m_problem_id;
+        m_problem_id = x.m_problem_id;
 
-                    m_iteration_id = x.m_iteration_id;
+        m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-           m_iteration_id == x.m_iteration_id);
+               m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,7 +209,6 @@ public:
         return m_problem_id;
     }
 
-
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -237,8 +236,6 @@ public:
     {
         return m_iteration_id;
     }
-
-
 
 private:
 
@@ -275,17 +272,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-                    m_node_status = x.m_node_status;
+        m_node_status = x.m_node_status;
 
-                    m_task_status = x.m_task_status;
+        m_task_status = x.m_task_status;
 
-                    m_error_code = x.m_error_code;
+        m_error_code = x.m_error_code;
 
-                    m_error_description = x.m_error_description;
+        m_error_description = x.m_error_description;
 
-                    m_node_name = x.m_node_name;
+        m_node_name = x.m_node_name;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -312,17 +309,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-                    m_node_status = x.m_node_status;
+        m_node_status = x.m_node_status;
 
-                    m_task_status = x.m_task_status;
+        m_task_status = x.m_task_status;
 
-                    m_error_code = x.m_error_code;
+        m_error_code = x.m_error_code;
 
-                    m_error_description = x.m_error_description;
+        m_error_description = x.m_error_description;
 
-                    m_node_name = x.m_node_name;
+        m_node_name = x.m_node_name;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -352,11 +349,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-           m_task_status == x.m_task_status &&
-           m_error_code == x.m_error_code &&
-           m_error_description == x.m_error_description &&
-           m_node_name == x.m_node_name &&
-           m_task_id == x.m_task_id);
+               m_task_status == x.m_task_status &&
+               m_error_code == x.m_error_code &&
+               m_error_description == x.m_error_description &&
+               m_node_name == x.m_node_name &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -397,7 +394,6 @@ public:
         return m_node_status;
     }
 
-
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -426,7 +422,6 @@ public:
         return m_task_status;
     }
 
-
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -454,7 +449,6 @@ public:
     {
         return m_error_code;
     }
-
 
     /*!
      * @brief This function copies the value in member error_description
@@ -494,7 +488,6 @@ public:
         return m_error_description;
     }
 
-
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -533,7 +526,6 @@ public:
         return m_node_name;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -571,8 +563,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -637,15 +627,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-                    m_cmd_node = x.m_cmd_node;
+        m_cmd_node = x.m_cmd_node;
 
-                    m_cmd_task = x.m_cmd_task;
+        m_cmd_task = x.m_cmd_task;
 
-                    m_target_node = x.m_target_node;
+        m_target_node = x.m_target_node;
 
-                    m_source_node = x.m_source_node;
+        m_source_node = x.m_source_node;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -671,15 +661,15 @@ public:
             const NodeControlImpl& x)
     {
 
-                    m_cmd_node = x.m_cmd_node;
+        m_cmd_node = x.m_cmd_node;
 
-                    m_cmd_task = x.m_cmd_task;
+        m_cmd_task = x.m_cmd_task;
 
-                    m_target_node = x.m_target_node;
+        m_target_node = x.m_target_node;
 
-                    m_source_node = x.m_source_node;
+        m_source_node = x.m_source_node;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -708,10 +698,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-           m_cmd_task == x.m_cmd_task &&
-           m_target_node == x.m_target_node &&
-           m_source_node == x.m_source_node &&
-           m_task_id == x.m_task_id);
+               m_cmd_task == x.m_cmd_task &&
+               m_target_node == x.m_target_node &&
+               m_source_node == x.m_source_node &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -752,7 +742,6 @@ public:
         return m_cmd_node;
     }
 
-
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -780,7 +769,6 @@ public:
     {
         return m_cmd_task;
     }
-
 
     /*!
      * @brief This function copies the value in member target_node
@@ -820,7 +808,6 @@ public:
         return m_target_node;
     }
 
-
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -858,7 +845,6 @@ public:
     {
         return m_source_node;
     }
-
 
     /*!
      * @brief This function copies the value in member task_id
@@ -898,8 +884,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -938,35 +922,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-                    m_modality = x.m_modality;
+        m_modality = x.m_modality;
 
-                    m_problem_short_description = x.m_problem_short_description;
+        m_problem_short_description = x.m_problem_short_description;
 
-                    m_problem_definition = x.m_problem_definition;
+        m_problem_definition = x.m_problem_definition;
 
-                    m_inputs = x.m_inputs;
+        m_inputs = x.m_inputs;
 
-                    m_outputs = x.m_outputs;
+        m_outputs = x.m_outputs;
 
-                    m_minimum_samples = x.m_minimum_samples;
+        m_minimum_samples = x.m_minimum_samples;
 
-                    m_maximum_samples = x.m_maximum_samples;
+        m_maximum_samples = x.m_maximum_samples;
 
-                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-                    m_previous_iteration = x.m_previous_iteration;
+        m_previous_iteration = x.m_previous_iteration;
 
-                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-                    m_geo_location_continent = x.m_geo_location_continent;
+        m_geo_location_continent = x.m_geo_location_continent;
 
-                    m_geo_location_region = x.m_geo_location_region;
+        m_geo_location_region = x.m_geo_location_region;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1002,35 +986,35 @@ public:
             const UserInputImpl& x)
     {
 
-                    m_modality = x.m_modality;
+        m_modality = x.m_modality;
 
-                    m_problem_short_description = x.m_problem_short_description;
+        m_problem_short_description = x.m_problem_short_description;
 
-                    m_problem_definition = x.m_problem_definition;
+        m_problem_definition = x.m_problem_definition;
 
-                    m_inputs = x.m_inputs;
+        m_inputs = x.m_inputs;
 
-                    m_outputs = x.m_outputs;
+        m_outputs = x.m_outputs;
 
-                    m_minimum_samples = x.m_minimum_samples;
+        m_minimum_samples = x.m_minimum_samples;
 
-                    m_maximum_samples = x.m_maximum_samples;
+        m_maximum_samples = x.m_maximum_samples;
 
-                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-                    m_previous_iteration = x.m_previous_iteration;
+        m_previous_iteration = x.m_previous_iteration;
 
-                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-                    m_geo_location_continent = x.m_geo_location_continent;
+        m_geo_location_continent = x.m_geo_location_continent;
 
-                    m_geo_location_region = x.m_geo_location_region;
+        m_geo_location_region = x.m_geo_location_region;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1069,20 +1053,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-           m_problem_short_description == x.m_problem_short_description &&
-           m_problem_definition == x.m_problem_definition &&
-           m_inputs == x.m_inputs &&
-           m_outputs == x.m_outputs &&
-           m_minimum_samples == x.m_minimum_samples &&
-           m_maximum_samples == x.m_maximum_samples &&
-           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-           m_previous_iteration == x.m_previous_iteration &&
-           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-           m_geo_location_continent == x.m_geo_location_continent &&
-           m_geo_location_region == x.m_geo_location_region &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_problem_short_description == x.m_problem_short_description &&
+               m_problem_definition == x.m_problem_definition &&
+               m_inputs == x.m_inputs &&
+               m_outputs == x.m_outputs &&
+               m_minimum_samples == x.m_minimum_samples &&
+               m_maximum_samples == x.m_maximum_samples &&
+               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+               m_previous_iteration == x.m_previous_iteration &&
+               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+               m_geo_location_continent == x.m_geo_location_continent &&
+               m_geo_location_region == x.m_geo_location_region &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1133,7 +1117,6 @@ public:
         return m_modality;
     }
 
-
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1171,7 +1154,6 @@ public:
     {
         return m_problem_short_description;
     }
-
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1211,7 +1193,6 @@ public:
         return m_problem_definition;
     }
 
-
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1249,7 +1230,6 @@ public:
     {
         return m_inputs;
     }
-
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1289,7 +1269,6 @@ public:
         return m_outputs;
     }
 
-
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1317,7 +1296,6 @@ public:
     {
         return m_minimum_samples;
     }
-
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1347,7 +1325,6 @@ public:
         return m_maximum_samples;
     }
 
-
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1375,7 +1352,6 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
-
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1405,7 +1381,6 @@ public:
         return m_previous_iteration;
     }
 
-
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1434,7 +1409,6 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
-
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1462,7 +1436,6 @@ public:
     {
         return m_desired_carbon_footprint;
     }
-
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1502,7 +1475,6 @@ public:
         return m_geo_location_continent;
     }
 
-
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1540,7 +1512,6 @@ public:
     {
         return m_geo_location_region;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1580,7 +1551,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1618,8 +1588,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -1669,13 +1637,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-                    m_keywords = x.m_keywords;
+        m_keywords = x.m_keywords;
 
-                    m_ml_model_metadata = x.m_ml_model_metadata;
+        m_ml_model_metadata = x.m_ml_model_metadata;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1700,13 +1668,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-                    m_keywords = x.m_keywords;
+        m_keywords = x.m_keywords;
 
-                    m_ml_model_metadata = x.m_ml_model_metadata;
+        m_ml_model_metadata = x.m_ml_model_metadata;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1734,9 +1702,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-           m_ml_model_metadata == x.m_ml_model_metadata &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_ml_model_metadata == x.m_ml_model_metadata &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1787,7 +1755,6 @@ public:
         return m_keywords;
     }
 
-
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1825,7 +1792,6 @@ public:
     {
         return m_ml_model_metadata;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1865,7 +1831,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1904,8 +1869,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     std::vector<std::string> m_keywords;
@@ -1943,11 +1906,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-                    m_app_requirements = x.m_app_requirements;
+        m_app_requirements = x.m_app_requirements;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -1971,11 +1934,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-                    m_app_requirements = x.m_app_requirements;
+        m_app_requirements = x.m_app_requirements;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2002,8 +1965,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2054,7 +2017,6 @@ public:
         return m_app_requirements;
     }
 
-
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2092,7 +2054,6 @@ public:
     {
         return m_extra_data;
     }
-
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2132,8 +2093,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2170,13 +2129,13 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-                    m_max_memory_footprint = x.m_max_memory_footprint;
+        m_max_memory_footprint = x.m_max_memory_footprint;
 
-                    m_hardware_required = x.m_hardware_required;
+        m_hardware_required = x.m_hardware_required;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2201,13 +2160,13 @@ public:
             const HWConstraintsImpl& x)
     {
 
-                    m_max_memory_footprint = x.m_max_memory_footprint;
+        m_max_memory_footprint = x.m_max_memory_footprint;
 
-                    m_hardware_required = x.m_hardware_required;
+        m_hardware_required = x.m_hardware_required;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2235,9 +2194,9 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-           m_hardware_required == x.m_hardware_required &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_hardware_required == x.m_hardware_required &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2278,7 +2237,6 @@ public:
         return m_max_memory_footprint;
     }
 
-
     /*!
      * @brief This function copies the value in member hardware_required
      * @param _hardware_required New value to be copied in member hardware_required
@@ -2316,7 +2274,6 @@ public:
     {
         return m_hardware_required;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2356,7 +2313,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2395,8 +2351,6 @@ public:
         return m_task_id;
     }
 
-
-
 private:
 
     uint32_t m_max_memory_footprint{0};
@@ -2434,23 +2388,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-                    m_model_path = x.m_model_path;
+        m_model_path = x.m_model_path;
 
-                    m_model = x.m_model;
+        m_model = x.m_model;
 
-                    m_raw_model = x.m_raw_model;
+        m_raw_model = x.m_raw_model;
 
-                    m_model_properties_path = x.m_model_properties_path;
+        m_model_properties_path = x.m_model_properties_path;
 
-                    m_model_properties = x.m_model_properties;
+        m_model_properties = x.m_model_properties;
 
-                    m_input_batch = x.m_input_batch;
+        m_input_batch = x.m_input_batch;
 
-                    m_target_latency = x.m_target_latency;
+        m_target_latency = x.m_target_latency;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2480,23 +2434,23 @@ public:
             const MLModelImpl& x)
     {
 
-                    m_model_path = x.m_model_path;
+        m_model_path = x.m_model_path;
 
-                    m_model = x.m_model;
+        m_model = x.m_model;
 
-                    m_raw_model = x.m_raw_model;
+        m_raw_model = x.m_raw_model;
 
-                    m_model_properties_path = x.m_model_properties_path;
+        m_model_properties_path = x.m_model_properties_path;
 
-                    m_model_properties = x.m_model_properties;
+        m_model_properties = x.m_model_properties;
 
-                    m_input_batch = x.m_input_batch;
+        m_input_batch = x.m_input_batch;
 
-                    m_target_latency = x.m_target_latency;
+        m_target_latency = x.m_target_latency;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2529,14 +2483,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-           m_model == x.m_model &&
-           m_raw_model == x.m_raw_model &&
-           m_model_properties_path == x.m_model_properties_path &&
-           m_model_properties == x.m_model_properties &&
-           m_input_batch == x.m_input_batch &&
-           m_target_latency == x.m_target_latency &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_model == x.m_model &&
+               m_raw_model == x.m_raw_model &&
+               m_model_properties_path == x.m_model_properties_path &&
+               m_model_properties == x.m_model_properties &&
+               m_input_batch == x.m_input_batch &&
+               m_target_latency == x.m_target_latency &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2587,7 +2541,6 @@ public:
         return m_model_path;
     }
 
-
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2625,7 +2578,6 @@ public:
     {
         return m_model;
     }
-
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2665,7 +2617,6 @@ public:
         return m_raw_model;
     }
 
-
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2703,7 +2654,6 @@ public:
     {
         return m_model_properties_path;
     }
-
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2743,7 +2693,6 @@ public:
         return m_model_properties;
     }
 
-
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2782,7 +2731,6 @@ public:
         return m_input_batch;
     }
 
-
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2810,7 +2758,6 @@ public:
     {
         return m_target_latency;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2850,7 +2797,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2888,8 +2834,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -2933,19 +2877,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-                    m_hw_description = x.m_hw_description;
+        m_hw_description = x.m_hw_description;
 
-                    m_power_consumption = x.m_power_consumption;
+        m_power_consumption = x.m_power_consumption;
 
-                    m_latency = x.m_latency;
+        m_latency = x.m_latency;
 
-                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -2973,19 +2917,19 @@ public:
             const HWResourceImpl& x)
     {
 
-                    m_hw_description = x.m_hw_description;
+        m_hw_description = x.m_hw_description;
 
-                    m_power_consumption = x.m_power_consumption;
+        m_power_consumption = x.m_power_consumption;
 
-                    m_latency = x.m_latency;
+        m_latency = x.m_latency;
 
-                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3016,12 +2960,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-           m_power_consumption == x.m_power_consumption &&
-           m_latency == x.m_latency &&
-           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_power_consumption == x.m_power_consumption &&
+               m_latency == x.m_latency &&
+               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3072,7 +3016,6 @@ public:
         return m_hw_description;
     }
 
-
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -3100,7 +3043,6 @@ public:
     {
         return m_power_consumption;
     }
-
 
     /*!
      * @brief This function sets a value in member latency
@@ -3130,7 +3072,6 @@ public:
         return m_latency;
     }
 
-
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3159,7 +3100,6 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
-
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3187,7 +3127,6 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3227,7 +3166,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3265,8 +3203,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 
@@ -3308,15 +3244,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-                    m_carbon_footprint = x.m_carbon_footprint;
+        m_carbon_footprint = x.m_carbon_footprint;
 
-                    m_energy_consumption = x.m_energy_consumption;
+        m_energy_consumption = x.m_energy_consumption;
 
-                    m_carbon_intensity = x.m_carbon_intensity;
+        m_carbon_intensity = x.m_carbon_intensity;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
     }
 
@@ -3342,15 +3278,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-                    m_carbon_footprint = x.m_carbon_footprint;
+        m_carbon_footprint = x.m_carbon_footprint;
 
-                    m_energy_consumption = x.m_energy_consumption;
+        m_energy_consumption = x.m_energy_consumption;
 
-                    m_carbon_intensity = x.m_carbon_intensity;
+        m_carbon_intensity = x.m_carbon_intensity;
 
-                    m_extra_data = x.m_extra_data;
+        m_extra_data = x.m_extra_data;
 
-                    m_task_id = x.m_task_id;
+        m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3379,10 +3315,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-           m_energy_consumption == x.m_energy_consumption &&
-           m_carbon_intensity == x.m_carbon_intensity &&
-           m_extra_data == x.m_extra_data &&
-           m_task_id == x.m_task_id);
+               m_energy_consumption == x.m_energy_consumption &&
+               m_carbon_intensity == x.m_carbon_intensity &&
+               m_extra_data == x.m_extra_data &&
+               m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3423,7 +3359,6 @@ public:
         return m_carbon_footprint;
     }
 
-
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3452,7 +3387,6 @@ public:
         return m_energy_consumption;
     }
 
-
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3480,7 +3414,6 @@ public:
     {
         return m_carbon_intensity;
     }
-
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3520,7 +3453,6 @@ public:
         return m_extra_data;
     }
 
-
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3558,8 +3490,6 @@ public:
     {
         return m_task_id;
     }
-
-
 
 private:
 

--- a/sustainml_modules/test/communication/types/typesImpl.idl
+++ b/sustainml_modules/test/communication/types/typesImpl.idl
@@ -98,6 +98,7 @@ struct AppRequirementsImpl
 struct HWConstraintsImpl
 {
     unsigned long max_memory_footprint;
+    sequence<string> hardware_required;
     sequence<octet> extra_data;
     @key TaskIdImpl task_id;
  };

--- a/sustainml_modules/test/communication/types/typesImplCdrAux.hpp
+++ b/sustainml_modules/test/communication/types/typesImplCdrAux.hpp
@@ -36,7 +36,7 @@ constexpr uint32_t MLModelImpl_max_key_cdr_typesize {12UL};
 constexpr uint32_t MLModelMetadataImpl_max_cdr_typesize {36UL};
 constexpr uint32_t MLModelMetadataImpl_max_key_cdr_typesize {12UL};
 
-constexpr uint32_t HWConstraintsImpl_max_cdr_typesize {24UL};
+constexpr uint32_t HWConstraintsImpl_max_cdr_typesize {32UL};
 constexpr uint32_t HWConstraintsImpl_max_key_cdr_typesize {12UL};
 
 constexpr uint32_t CO2FootprintImpl_max_cdr_typesize {48UL};

--- a/sustainml_modules/test/communication/types/typesImplCdrAux.ipp
+++ b/sustainml_modules/test/communication/types/typesImplCdrAux.ipp
@@ -50,11 +50,11 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.problem_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.problem_id(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.iteration_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.iteration_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -76,7 +76,7 @@ eProsima_user_DllExport void serialize(
     scdr
         << eprosima::fastcdr::MemberId(0) << data.problem_id()
         << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -93,13 +93,13 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.problem_id();
-                        break;
+                                        case 0:
+                                                dcdr >> data.problem_id();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.iteration_id();
-                        break;
+                                        case 1:
+                                                dcdr >> data.iteration_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -116,11 +116,12 @@ void serialize_key(
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.problem_id();
+                        scdr << data.problem_id();
 
-    scdr << data.iteration_id();
+                        scdr << data.iteration_id();
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -138,23 +139,23 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.node_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.task_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.task_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.error_code(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.error_code(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.error_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.error_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.node_name(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.node_name(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -180,7 +181,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(3) << data.error_description()
         << eprosima::fastcdr::MemberId(4) << data.node_name()
         << eprosima::fastcdr::MemberId(5) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -197,29 +198,29 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.node_status();
-                        break;
+                                        case 0:
+                                                dcdr >> data.node_status();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.task_status();
-                        break;
+                                        case 1:
+                                                dcdr >> data.task_status();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.error_code();
-                        break;
+                                        case 2:
+                                                dcdr >> data.error_code();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.error_description();
-                        break;
+                                        case 3:
+                                                dcdr >> data.error_description();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.node_name();
-                        break;
+                                        case 4:
+                                                dcdr >> data.node_name();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 5:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -233,18 +234,21 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.node_name();
+                        scdr << data.node_name();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
+
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -262,20 +266,20 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.cmd_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.cmd_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.cmd_task(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.cmd_task(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.target_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.target_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.source_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.source_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -300,7 +304,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.target_node()
         << eprosima::fastcdr::MemberId(3) << data.source_node()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -317,25 +321,25 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.cmd_node();
-                        break;
+                                        case 0:
+                                                dcdr >> data.cmd_node();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.cmd_task();
-                        break;
+                                        case 1:
+                                                dcdr >> data.cmd_task();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.target_node();
-                        break;
+                                        case 2:
+                                                dcdr >> data.target_node();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.source_node();
-                        break;
+                                        case 3:
+                                                dcdr >> data.source_node();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -349,18 +353,19 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    scdr << data.source_node();
+                        scdr << data.source_node();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -378,50 +383,50 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.modality(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.modality(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.problem_short_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.problem_short_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.problem_definition(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.problem_definition(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.inputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.inputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.outputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.outputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.minimum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.minimum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.maximum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.maximum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.optimize_carbon_footprint_manual(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.optimize_carbon_footprint_manual(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.previous_iteration(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.previous_iteration(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                    data.optimize_carbon_footprint_auto(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                data.optimize_carbon_footprint_auto(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                    data.desired_carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                data.desired_carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                    data.geo_location_continent(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                data.geo_location_continent(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                    data.geo_location_region(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                data.geo_location_region(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -456,7 +461,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
         << eprosima::fastcdr::MemberId(13) << data.extra_data()
         << eprosima::fastcdr::MemberId(14) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -473,65 +478,65 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.modality();
-                        break;
+                                        case 0:
+                                                dcdr >> data.modality();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.problem_short_description();
-                        break;
+                                        case 1:
+                                                dcdr >> data.problem_short_description();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.problem_definition();
-                        break;
+                                        case 2:
+                                                dcdr >> data.problem_definition();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.inputs();
-                        break;
+                                        case 3:
+                                                dcdr >> data.inputs();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.outputs();
-                        break;
+                                        case 4:
+                                                dcdr >> data.outputs();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.minimum_samples();
-                        break;
+                                        case 5:
+                                                dcdr >> data.minimum_samples();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.maximum_samples();
-                        break;
+                                        case 6:
+                                                dcdr >> data.maximum_samples();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.optimize_carbon_footprint_manual();
-                        break;
+                                        case 7:
+                                                dcdr >> data.optimize_carbon_footprint_manual();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.previous_iteration();
-                        break;
+                                        case 8:
+                                                dcdr >> data.previous_iteration();
+                                            break;
 
-                    case 9:
-                        dcdr >> data.optimize_carbon_footprint_auto();
-                        break;
+                                        case 9:
+                                                dcdr >> data.optimize_carbon_footprint_auto();
+                                            break;
 
-                    case 10:
-                        dcdr >> data.desired_carbon_footprint();
-                        break;
+                                        case 10:
+                                                dcdr >> data.desired_carbon_footprint();
+                                            break;
 
-                    case 11:
-                        dcdr >> data.geo_location_continent();
-                        break;
+                                        case 11:
+                                                dcdr >> data.geo_location_continent();
+                                            break;
 
-                    case 12:
-                        dcdr >> data.geo_location_region();
-                        break;
+                                        case 12:
+                                                dcdr >> data.geo_location_region();
+                                            break;
 
-                    case 13:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 13:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 14:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 14:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -545,16 +550,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UserInputImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -572,17 +578,17 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.keywords(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.keywords(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.ml_model_metadata(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.ml_model_metadata(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -606,7 +612,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
         << eprosima::fastcdr::MemberId(2) << data.extra_data()
         << eprosima::fastcdr::MemberId(3) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -623,21 +629,21 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.keywords();
-                        break;
+                                        case 0:
+                                                dcdr >> data.keywords();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.ml_model_metadata();
-                        break;
+                                        case 1:
+                                                dcdr >> data.ml_model_metadata();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -651,16 +657,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelMetadataImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -678,14 +685,14 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.app_requirements(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.app_requirements(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -708,7 +715,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(0) << data.app_requirements()
         << eprosima::fastcdr::MemberId(1) << data.extra_data()
         << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -725,17 +732,17 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.app_requirements();
-                        break;
+                                        case 0:
+                                                dcdr >> data.app_requirements();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -749,16 +756,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppRequirementsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -776,14 +784,17 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.max_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.max_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.hardware_required(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -804,9 +815,10 @@ eProsima_user_DllExport void serialize(
 
     scdr
         << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.extra_data()
-        << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -823,17 +835,21 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.max_memory_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.max_memory_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.hardware_required();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
+
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -847,16 +863,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWConstraintsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -874,32 +891,32 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.model_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.model_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.raw_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.raw_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.model_properties_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.model_properties_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.model_properties(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.model_properties(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.input_batch(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.input_batch(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.target_latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.target_latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -928,7 +945,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(6) << data.target_latency()
         << eprosima::fastcdr::MemberId(7) << data.extra_data()
         << eprosima::fastcdr::MemberId(8) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -945,41 +962,41 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.model_path();
-                        break;
+                                        case 0:
+                                                dcdr >> data.model_path();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.model();
-                        break;
+                                        case 1:
+                                                dcdr >> data.model();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.raw_model();
-                        break;
+                                        case 2:
+                                                dcdr >> data.raw_model();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.model_properties_path();
-                        break;
+                                        case 3:
+                                                dcdr >> data.model_properties_path();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.model_properties();
-                        break;
+                                        case 4:
+                                                dcdr >> data.model_properties();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.input_batch();
-                        break;
+                                        case 5:
+                                                dcdr >> data.input_batch();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.target_latency();
-                        break;
+                                        case 6:
+                                                dcdr >> data.target_latency();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 7:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 8:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -993,16 +1010,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -1020,26 +1038,26 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.hw_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.hw_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.power_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.power_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.memory_footprint_of_ml_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.memory_footprint_of_ml_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.max_hw_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.max_hw_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1066,7 +1084,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
         << eprosima::fastcdr::MemberId(5) << data.extra_data()
         << eprosima::fastcdr::MemberId(6) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -1083,33 +1101,33 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.hw_description();
-                        break;
+                                        case 0:
+                                                dcdr >> data.hw_description();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.power_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.power_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.latency();
-                        break;
+                                        case 2:
+                                                dcdr >> data.latency();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.memory_footprint_of_ml_model();
-                        break;
+                                        case 3:
+                                                dcdr >> data.memory_footprint_of_ml_model();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.max_hw_memory_footprint();
-                        break;
+                                        case 4:
+                                                dcdr >> data.max_hw_memory_footprint();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 5:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 6:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1123,16 +1141,17 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWResourceImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
 
 template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
@@ -1150,20 +1169,20 @@ eProsima_user_DllExport size_t calculate_serialized_size(
                                 current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.energy_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.energy_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.carbon_intensity(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.carbon_intensity(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1188,7 +1207,7 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
         << eprosima::fastcdr::MemberId(3) << data.extra_data()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
@@ -1205,25 +1224,25 @@ eProsima_user_DllExport void deserialize(
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.carbon_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.carbon_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.energy_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.energy_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.carbon_intensity();
-                        break;
+                                        case 2:
+                                                dcdr >> data.carbon_intensity();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 3:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1237,16 +1256,18 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
     static_cast<void>(scdr);
     static_cast<void>(data);
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
+
+
 
 } // namespace fastcdr
 } // namespace eprosima

--- a/sustainml_modules/test/communication/types/typesImplCdrAux.ipp
+++ b/sustainml_modules/test/communication/types/typesImplCdrAux.ipp
@@ -32,66 +32,66 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-    namespace fastcdr {
+namespace fastcdr {
 
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const TaskIdImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const TaskIdImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
-
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.problem_id(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.iteration_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.problem_id(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.iteration_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.problem_id()
-                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                TaskIdImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.problem_id()
+        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        TaskIdImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -110,95 +110,95 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const TaskIdImpl& data)
-        {
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const TaskIdImpl& data)
+{
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.problem_id();
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.problem_id();
 
-            scdr << data.iteration_id();
+    scdr << data.iteration_id();
 
-        }
+}
 
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeStatusImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeStatusImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
-
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.node_status(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.task_status(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.error_code(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.error_description(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.node_name(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.node_status(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.task_status(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.error_code(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.node_status()
-                << eprosima::fastcdr::MemberId(1) << data.task_status()
-                << eprosima::fastcdr::MemberId(2) << data.error_code()
-                << eprosima::fastcdr::MemberId(3) << data.error_description()
-                << eprosima::fastcdr::MemberId(4) << data.node_name()
-                << eprosima::fastcdr::MemberId(5) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.error_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeStatusImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.node_name(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.node_status()
+        << eprosima::fastcdr::MemberId(1) << data.task_status()
+        << eprosima::fastcdr::MemberId(2) << data.error_code()
+        << eprosima::fastcdr::MemberId(3) << data.error_description()
+        << eprosima::fastcdr::MemberId(4) << data.node_name()
+        << eprosima::fastcdr::MemberId(5) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeStatusImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -233,95 +233,95 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeStatusImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.node_name();
-
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const NodeControlImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeStatusImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.cmd_node(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.node_name();
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.cmd_task(), current_alignment);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.target_node(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.source_node(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const NodeControlImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.cmd_node(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.cmd_task(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.target_node(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-                << eprosima::fastcdr::MemberId(2) << data.target_node()
-                << eprosima::fastcdr::MemberId(3) << data.source_node()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.source_node(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                NodeControlImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+        << eprosima::fastcdr::MemberId(2) << data.target_node()
+        << eprosima::fastcdr::MemberId(3) << data.source_node()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        NodeControlImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -352,135 +352,135 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const NodeControlImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            scdr << data.source_node();
-
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const UserInputImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const NodeControlImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.modality(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    scdr << data.source_node();
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.problem_short_description(), current_alignment);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.problem_definition(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.inputs(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const UserInputImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.outputs(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.minimum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.maximum_samples(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.optimize_carbon_footprint_manual(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.previous_iteration(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                            data.optimize_carbon_footprint_auto(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                            data.desired_carbon_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                            data.geo_location_continent(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                            data.geo_location_region(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.modality(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.problem_short_description(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.problem_definition(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.modality()
-                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-                << eprosima::fastcdr::MemberId(3) << data.inputs()
-                << eprosima::fastcdr::MemberId(4) << data.outputs()
-                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-                << eprosima::fastcdr::MemberId(13) << data.extra_data()
-                << eprosima::fastcdr::MemberId(14) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.inputs(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                UserInputImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.outputs(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.minimum_samples(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.maximum_samples(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    data.optimize_carbon_footprint_manual(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    data.previous_iteration(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                    data.optimize_carbon_footprint_auto(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                    data.desired_carbon_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                    data.geo_location_continent(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                    data.geo_location_region(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.modality()
+        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+        << eprosima::fastcdr::MemberId(3) << data.inputs()
+        << eprosima::fastcdr::MemberId(4) << data.outputs()
+        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+        << eprosima::fastcdr::MemberId(13) << data.extra_data()
+        << eprosima::fastcdr::MemberId(14) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        UserInputImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -551,89 +551,89 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const UserInputImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelMetadataImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const UserInputImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.keywords(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.ml_model_metadata(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.extra_data(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelMetadataImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.keywords(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.ml_model_metadata(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.extra_data(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.keywords()
-                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-                << eprosima::fastcdr::MemberId(2) << data.extra_data()
-                << eprosima::fastcdr::MemberId(3) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.task_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelMetadataImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.keywords()
+        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelMetadataImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -660,85 +660,85 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelMetadataImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const AppRequirementsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelMetadataImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.app_requirements(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.extra_data(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.task_id(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const AppRequirementsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.app_requirements(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.extra_data(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.task_id(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-                << eprosima::fastcdr::MemberId(1) << data.extra_data()
-                << eprosima::fastcdr::MemberId(2) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                AppRequirementsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+        << eprosima::fastcdr::MemberId(1) << data.extra_data()
+        << eprosima::fastcdr::MemberId(2) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        AppRequirementsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -761,89 +761,89 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const AppRequirementsImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWConstraintsImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const AppRequirementsImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.max_memory_footprint(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.hardware_required(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.extra_data(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWConstraintsImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.max_memory_footprint(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.hardware_required(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.extra_data(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.hardware_required()
-                << eprosima::fastcdr::MemberId(2) << data.extra_data()
-                << eprosima::fastcdr::MemberId(3) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.task_id(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWConstraintsImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+        << eprosima::fastcdr::MemberId(2) << data.extra_data()
+        << eprosima::fastcdr::MemberId(3) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWConstraintsImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -870,109 +870,109 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWConstraintsImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const MLModelImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWConstraintsImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.model_path(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.model(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.raw_model(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const MLModelImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.model_properties_path(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.model_properties(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.input_batch(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.target_latency(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.model_path(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.raw_model(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.model_path()
-                << eprosima::fastcdr::MemberId(1) << data.model()
-                << eprosima::fastcdr::MemberId(2) << data.raw_model()
-                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-                << eprosima::fastcdr::MemberId(4) << data.model_properties()
-                << eprosima::fastcdr::MemberId(5) << data.input_batch()
-                << eprosima::fastcdr::MemberId(6) << data.target_latency()
-                << eprosima::fastcdr::MemberId(7) << data.extra_data()
-                << eprosima::fastcdr::MemberId(8) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.model_properties_path(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                MLModelImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.model_properties(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.input_batch(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.target_latency(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.model_path()
+        << eprosima::fastcdr::MemberId(1) << data.model()
+        << eprosima::fastcdr::MemberId(2) << data.raw_model()
+        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+        << eprosima::fastcdr::MemberId(4) << data.model_properties()
+        << eprosima::fastcdr::MemberId(5) << data.input_batch()
+        << eprosima::fastcdr::MemberId(6) << data.target_latency()
+        << eprosima::fastcdr::MemberId(7) << data.extra_data()
+        << eprosima::fastcdr::MemberId(8) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        MLModelImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1019,101 +1019,101 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const MLModelImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const HWResourceImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const MLModelImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.hw_description(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.power_consumption(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.latency(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const HWResourceImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.memory_footprint_of_ml_model(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.max_hw_memory_footprint(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                            data.extra_data(), current_alignment);
-
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                            data.task_id(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.hw_description(), current_alignment);
 
-            return calculated_size;
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.power_consumption(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.latency(), current_alignment);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.hw_description()
-                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.latency()
-                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-                << eprosima::fastcdr::MemberId(5) << data.extra_data()
-                << eprosima::fastcdr::MemberId(6) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.memory_footprint_of_ml_model(), current_alignment);
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                HWResourceImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.max_hw_memory_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                    data.task_id(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.hw_description()
+        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.latency()
+        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+        << eprosima::fastcdr::MemberId(5) << data.extra_data()
+        << eprosima::fastcdr::MemberId(6) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
+
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        HWResourceImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1152,93 +1152,93 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const HWResourceImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
-
-
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
-
-        }
-
-        template < >
-        eProsima_user_DllExport size_t calculate_serialized_size(
-                eprosima::fastcdr::CdrSizeCalculator& calculator,
-                const CO2FootprintImpl& data,
-                size_t& current_alignment)
-        {
-            static_cast < void > (data);
-
-            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-            size_t calculated_size {
-                calculator.begin_calculate_type_serialized_size(
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    current_alignment)
-            };
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const HWResourceImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                            data.carbon_footprint(), current_alignment);
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                            data.energy_consumption(), current_alignment);
+}
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                            data.carbon_intensity(), current_alignment);
+template < >
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const CO2FootprintImpl& data,
+        size_t& current_alignment)
+{
+    static_cast < void > (data);
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                            data.extra_data(), current_alignment);
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {
+        calculator.begin_calculate_type_serialized_size(
+            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            current_alignment)
+    };
 
-            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                            data.task_id(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                    data.carbon_footprint(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                    data.energy_consumption(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                    data.carbon_intensity(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                    data.extra_data(), current_alignment);
+
+    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                    data.task_id(), current_alignment);
 
 
-            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-            return calculated_size;
-        }
+    return calculated_size;
+}
 
-        template < >
-        eProsima_user_DllExport void serialize(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
-            eprosima::fastcdr::Cdr::state current_state(
-                    scdr);
-            scdr.begin_serialize_type(current_state,
-                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+template < >
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(
+        scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-            scdr
-                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-                << eprosima::fastcdr::MemberId(3) << data.extra_data()
-                << eprosima::fastcdr::MemberId(4) << data.task_id()
-            ;
-            scdr.end_serialize_type(current_state);
-        }
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+        << eprosima::fastcdr::MemberId(3) << data.extra_data()
+        << eprosima::fastcdr::MemberId(4) << data.task_id()
+    ;
+    scdr.end_serialize_type(current_state);
+}
 
-        template < >
-        eProsima_user_DllExport void deserialize(
-                eprosima::fastcdr::Cdr& cdr,
-                CO2FootprintImpl& data)
-        {
-            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+template < >
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        CO2FootprintImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
@@ -1269,24 +1269,24 @@ namespace eprosima {
                 }
                 return ret_value;
             });
-        }
+}
 
-        void serialize_key(
-                eprosima::fastcdr::Cdr& scdr,
-                const CO2FootprintImpl& data)
-        {
-            extern void serialize_key(
-                    Cdr& scdr,
-                    const TaskIdImpl& data);
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const CO2FootprintImpl& data)
+{
+    extern void serialize_key(
+        Cdr & scdr,
+        const TaskIdImpl& data);
 
 
-            static_cast < void > (scdr);
-            static_cast < void > (data);
-            serialize_key(scdr, data.task_id());
+    static_cast < void > (scdr);
+    static_cast < void > (data);
+    serialize_key(scdr, data.task_id());
 
-        }
+}
 
-    } // namespace fastcdr
+}     // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_modules/test/communication/types/typesImplCdrAux.ipp
+++ b/sustainml_modules/test/communication/types/typesImplCdrAux.ipp
@@ -32,74 +32,77 @@
 using namespace eprosima::fastcdr::exception;
 
 namespace eprosima {
-namespace fastcdr {
+    namespace fastcdr {
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const TaskIdImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const TaskIdImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.problem_id(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.iteration_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.problem_id(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.iteration_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.problem_id()
-        << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        TaskIdImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.problem_id()
+                << eprosima::fastcdr::MemberId(1) << data.iteration_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                TaskIdImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.problem_id();
-                                            break;
+                    case 0:
+                        dcdr >> data.problem_id();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.iteration_id();
-                                            break;
+                    case 1:
+                        dcdr >> data.iteration_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -107,120 +110,122 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const TaskIdImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const TaskIdImpl& data)
+        {
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.problem_id();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.problem_id();
 
-                        scdr << data.iteration_id();
+            scdr << data.iteration_id();
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeStatusImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeStatusImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.node_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.task_status(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.error_code(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.error_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.node_name(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.node_status(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.task_status(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.error_code(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.node_status()
-        << eprosima::fastcdr::MemberId(1) << data.task_status()
-        << eprosima::fastcdr::MemberId(2) << data.error_code()
-        << eprosima::fastcdr::MemberId(3) << data.error_description()
-        << eprosima::fastcdr::MemberId(4) << data.node_name()
-        << eprosima::fastcdr::MemberId(5) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.error_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeStatusImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.node_name(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.node_status()
+                << eprosima::fastcdr::MemberId(1) << data.task_status()
+                << eprosima::fastcdr::MemberId(2) << data.error_code()
+                << eprosima::fastcdr::MemberId(3) << data.error_description()
+                << eprosima::fastcdr::MemberId(4) << data.node_name()
+                << eprosima::fastcdr::MemberId(5) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeStatusImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.node_status();
-                                            break;
+                    case 0:
+                        dcdr >> data.node_status();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.task_status();
-                                            break;
+                    case 1:
+                        dcdr >> data.task_status();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.error_code();
-                                            break;
+                    case 2:
+                        dcdr >> data.error_code();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.error_description();
-                                            break;
+                    case 3:
+                        dcdr >> data.error_description();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.node_name();
-                                            break;
+                    case 4:
+                        dcdr >> data.node_name();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 5:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -228,118 +233,118 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeStatusImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeStatusImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.node_name();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.node_name();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const NodeControlImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-
-
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const NodeControlImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.cmd_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.cmd_task(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.target_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.source_node(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.cmd_node(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.cmd_task(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.target_node(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.cmd_node()
-        << eprosima::fastcdr::MemberId(1) << data.cmd_task()
-        << eprosima::fastcdr::MemberId(2) << data.target_node()
-        << eprosima::fastcdr::MemberId(3) << data.source_node()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.source_node(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        NodeControlImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.cmd_node()
+                << eprosima::fastcdr::MemberId(1) << data.cmd_task()
+                << eprosima::fastcdr::MemberId(2) << data.target_node()
+                << eprosima::fastcdr::MemberId(3) << data.source_node()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                NodeControlImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.cmd_node();
-                                            break;
+                    case 0:
+                        dcdr >> data.cmd_node();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.cmd_task();
-                                            break;
+                    case 1:
+                        dcdr >> data.cmd_task();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.target_node();
-                                            break;
+                    case 2:
+                        dcdr >> data.target_node();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.source_node();
-                                            break;
+                    case 3:
+                        dcdr >> data.source_node();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -347,196 +352,198 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const NodeControlImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const NodeControlImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        scdr << data.source_node();
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            scdr << data.source_node();
 
-                        serialize_key(scdr, data.task_id());
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const UserInputImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const UserInputImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.modality(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.problem_short_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.problem_definition(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.inputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.outputs(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.minimum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.maximum_samples(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.optimize_carbon_footprint_manual(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.previous_iteration(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                data.optimize_carbon_footprint_auto(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                data.desired_carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                data.geo_location_continent(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                data.geo_location_region(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.modality(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.problem_short_description(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.problem_definition(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.modality()
-        << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
-        << eprosima::fastcdr::MemberId(2) << data.problem_definition()
-        << eprosima::fastcdr::MemberId(3) << data.inputs()
-        << eprosima::fastcdr::MemberId(4) << data.outputs()
-        << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
-        << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
-        << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
-        << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
-        << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
-        << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
-        << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
-        << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
-        << eprosima::fastcdr::MemberId(13) << data.extra_data()
-        << eprosima::fastcdr::MemberId(14) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.inputs(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        UserInputImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.outputs(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.minimum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.maximum_samples(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.optimize_carbon_footprint_manual(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.previous_iteration(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                            data.optimize_carbon_footprint_auto(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                            data.desired_carbon_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                            data.geo_location_continent(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                            data.geo_location_region(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.modality()
+                << eprosima::fastcdr::MemberId(1) << data.problem_short_description()
+                << eprosima::fastcdr::MemberId(2) << data.problem_definition()
+                << eprosima::fastcdr::MemberId(3) << data.inputs()
+                << eprosima::fastcdr::MemberId(4) << data.outputs()
+                << eprosima::fastcdr::MemberId(5) << data.minimum_samples()
+                << eprosima::fastcdr::MemberId(6) << data.maximum_samples()
+                << eprosima::fastcdr::MemberId(7) << data.optimize_carbon_footprint_manual()
+                << eprosima::fastcdr::MemberId(8) << data.previous_iteration()
+                << eprosima::fastcdr::MemberId(9) << data.optimize_carbon_footprint_auto()
+                << eprosima::fastcdr::MemberId(10) << data.desired_carbon_footprint()
+                << eprosima::fastcdr::MemberId(11) << data.geo_location_continent()
+                << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
+                << eprosima::fastcdr::MemberId(13) << data.extra_data()
+                << eprosima::fastcdr::MemberId(14) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                UserInputImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.modality();
-                                            break;
+                    case 0:
+                        dcdr >> data.modality();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.problem_short_description();
-                                            break;
+                    case 1:
+                        dcdr >> data.problem_short_description();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.problem_definition();
-                                            break;
+                    case 2:
+                        dcdr >> data.problem_definition();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.inputs();
-                                            break;
+                    case 3:
+                        dcdr >> data.inputs();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.outputs();
-                                            break;
+                    case 4:
+                        dcdr >> data.outputs();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.minimum_samples();
-                                            break;
+                    case 5:
+                        dcdr >> data.minimum_samples();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.maximum_samples();
-                                            break;
+                    case 6:
+                        dcdr >> data.maximum_samples();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.optimize_carbon_footprint_manual();
-                                            break;
+                    case 7:
+                        dcdr >> data.optimize_carbon_footprint_manual();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.previous_iteration();
-                                            break;
+                    case 8:
+                        dcdr >> data.previous_iteration();
+                        break;
 
-                                        case 9:
-                                                dcdr >> data.optimize_carbon_footprint_auto();
-                                            break;
+                    case 9:
+                        dcdr >> data.optimize_carbon_footprint_auto();
+                        break;
 
-                                        case 10:
-                                                dcdr >> data.desired_carbon_footprint();
-                                            break;
+                    case 10:
+                        dcdr >> data.desired_carbon_footprint();
+                        break;
 
-                                        case 11:
-                                                dcdr >> data.geo_location_continent();
-                                            break;
+                    case 11:
+                        dcdr >> data.geo_location_continent();
+                        break;
 
-                                        case 12:
-                                                dcdr >> data.geo_location_region();
-                                            break;
+                    case 12:
+                        dcdr >> data.geo_location_region();
+                        break;
 
-                                        case 13:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 13:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 14:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 14:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -544,106 +551,108 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const UserInputImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const UserInputImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelMetadataImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelMetadataImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.keywords(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.ml_model_metadata(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.keywords(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.ml_model_metadata(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.extra_data(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.keywords()
-        << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
-        << eprosima::fastcdr::MemberId(2) << data.extra_data()
-        << eprosima::fastcdr::MemberId(3) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.task_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelMetadataImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.keywords()
+                << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
+                << eprosima::fastcdr::MemberId(2) << data.extra_data()
+                << eprosima::fastcdr::MemberId(3) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelMetadataImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.keywords();
-                                            break;
+                    case 0:
+                        dcdr >> data.keywords();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.ml_model_metadata();
-                                            break;
+                    case 1:
+                        dcdr >> data.ml_model_metadata();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 2:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 3:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -651,98 +660,100 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelMetadataImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelMetadataImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const AppRequirementsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const AppRequirementsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.app_requirements(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.app_requirements(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.task_id(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.app_requirements()
-        << eprosima::fastcdr::MemberId(1) << data.extra_data()
-        << eprosima::fastcdr::MemberId(2) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        AppRequirementsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.app_requirements()
+                << eprosima::fastcdr::MemberId(1) << data.extra_data()
+                << eprosima::fastcdr::MemberId(2) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                AppRequirementsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.app_requirements();
-                                            break;
+                    case 0:
+                        dcdr >> data.app_requirements();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 1:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 2:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -750,106 +761,108 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const AppRequirementsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const AppRequirementsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWConstraintsImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWConstraintsImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.max_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.hardware_required(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.max_memory_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.hardware_required(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.extra_data(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.hardware_required()
-        << eprosima::fastcdr::MemberId(2) << data.extra_data()
-        << eprosima::fastcdr::MemberId(3) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.task_id(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWConstraintsImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.max_memory_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.hardware_required()
+                << eprosima::fastcdr::MemberId(2) << data.extra_data()
+                << eprosima::fastcdr::MemberId(3) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWConstraintsImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.max_memory_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.max_memory_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.hardware_required();
-                                            break;
+                    case 1:
+                        dcdr >> data.hardware_required();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 2:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 3:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -857,146 +870,148 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWConstraintsImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWConstraintsImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const MLModelImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const MLModelImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.model_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.raw_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.model_properties_path(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.model_properties(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.input_batch(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.target_latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.model_path(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.raw_model(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.model_path()
-        << eprosima::fastcdr::MemberId(1) << data.model()
-        << eprosima::fastcdr::MemberId(2) << data.raw_model()
-        << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
-        << eprosima::fastcdr::MemberId(4) << data.model_properties()
-        << eprosima::fastcdr::MemberId(5) << data.input_batch()
-        << eprosima::fastcdr::MemberId(6) << data.target_latency()
-        << eprosima::fastcdr::MemberId(7) << data.extra_data()
-        << eprosima::fastcdr::MemberId(8) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.model_properties_path(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        MLModelImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.model_properties(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.input_batch(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.target_latency(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.model_path()
+                << eprosima::fastcdr::MemberId(1) << data.model()
+                << eprosima::fastcdr::MemberId(2) << data.raw_model()
+                << eprosima::fastcdr::MemberId(3) << data.model_properties_path()
+                << eprosima::fastcdr::MemberId(4) << data.model_properties()
+                << eprosima::fastcdr::MemberId(5) << data.input_batch()
+                << eprosima::fastcdr::MemberId(6) << data.target_latency()
+                << eprosima::fastcdr::MemberId(7) << data.extra_data()
+                << eprosima::fastcdr::MemberId(8) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                MLModelImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.model_path();
-                                            break;
+                    case 0:
+                        dcdr >> data.model_path();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.model();
-                                            break;
+                    case 1:
+                        dcdr >> data.model();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.raw_model();
-                                            break;
+                    case 2:
+                        dcdr >> data.raw_model();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.model_properties_path();
-                                            break;
+                    case 3:
+                        dcdr >> data.model_properties_path();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.model_properties();
-                                            break;
+                    case 4:
+                        dcdr >> data.model_properties();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.input_batch();
-                                            break;
+                    case 5:
+                        dcdr >> data.input_batch();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.target_latency();
-                                            break;
+                    case 6:
+                        dcdr >> data.target_latency();
+                        break;
 
-                                        case 7:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 7:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 8:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 8:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1004,130 +1019,132 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const MLModelImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const MLModelImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const HWResourceImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const HWResourceImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.hw_description(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.power_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.latency(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.memory_footprint_of_ml_model(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.max_hw_memory_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.hw_description(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.power_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.latency(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.hw_description()
-        << eprosima::fastcdr::MemberId(1) << data.power_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.latency()
-        << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
-        << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
-        << eprosima::fastcdr::MemberId(5) << data.extra_data()
-        << eprosima::fastcdr::MemberId(6) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.memory_footprint_of_ml_model(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        HWResourceImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.max_hw_memory_footprint(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                            data.extra_data(), current_alignment);
+
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.hw_description()
+                << eprosima::fastcdr::MemberId(1) << data.power_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.latency()
+                << eprosima::fastcdr::MemberId(3) << data.memory_footprint_of_ml_model()
+                << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
+                << eprosima::fastcdr::MemberId(5) << data.extra_data()
+                << eprosima::fastcdr::MemberId(6) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                HWResourceImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.hw_description();
-                                            break;
+                    case 0:
+                        dcdr >> data.hw_description();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.power_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.power_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.latency();
-                                            break;
+                    case 2:
+                        dcdr >> data.latency();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.memory_footprint_of_ml_model();
-                                            break;
+                    case 3:
+                        dcdr >> data.memory_footprint_of_ml_model();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.max_hw_memory_footprint();
-                                            break;
+                    case 4:
+                        dcdr >> data.max_hw_memory_footprint();
+                        break;
 
-                                        case 5:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 5:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 6:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 6:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1135,114 +1152,116 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const HWResourceImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const HWResourceImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
+        template < >
+        eProsima_user_DllExport size_t calculate_serialized_size(
+                eprosima::fastcdr::CdrSizeCalculator& calculator,
+                const CO2FootprintImpl& data,
+                size_t& current_alignment)
+        {
+            static_cast < void > (data);
 
-template<>
-eProsima_user_DllExport size_t calculate_serialized_size(
-        eprosima::fastcdr::CdrSizeCalculator& calculator,
-        const CO2FootprintImpl& data,
-        size_t& current_alignment)
-{
-    static_cast<void>(data);
-
-    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
-                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-                                current_alignment)};
-
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                data.carbon_footprint(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                data.energy_consumption(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                data.carbon_intensity(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                data.extra_data(), current_alignment);
-
-        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                data.task_id(), current_alignment);
+            eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+            size_t calculated_size {
+                calculator.begin_calculate_type_serialized_size(
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    current_alignment)
+            };
 
 
-    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                            data.carbon_footprint(), current_alignment);
 
-    return calculated_size;
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                            data.energy_consumption(), current_alignment);
 
-template<>
-eProsima_user_DllExport void serialize(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
-    eprosima::fastcdr::Cdr::state current_state(scdr);
-    scdr.begin_serialize_type(current_state,
-            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                            data.carbon_intensity(), current_alignment);
 
-    scdr
-        << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
-        << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
-        << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
-        << eprosima::fastcdr::MemberId(3) << data.extra_data()
-        << eprosima::fastcdr::MemberId(4) << data.task_id()
-;
-    scdr.end_serialize_type(current_state);
-}
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                            data.extra_data(), current_alignment);
 
-template<>
-eProsima_user_DllExport void deserialize(
-        eprosima::fastcdr::Cdr& cdr,
-        CO2FootprintImpl& data)
-{
-    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                            data.task_id(), current_alignment);
+
+
+            calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+            return calculated_size;
+        }
+
+        template < >
+        eProsima_user_DllExport void serialize(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
+            eprosima::fastcdr::Cdr::state current_state(
+                    scdr);
+            scdr.begin_serialize_type(current_state,
+                    eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+            scdr
+                << eprosima::fastcdr::MemberId(0) << data.carbon_footprint()
+                << eprosima::fastcdr::MemberId(1) << data.energy_consumption()
+                << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
+                << eprosima::fastcdr::MemberId(3) << data.extra_data()
+                << eprosima::fastcdr::MemberId(4) << data.task_id()
+            ;
+            scdr.end_serialize_type(current_state);
+        }
+
+        template < >
+        eProsima_user_DllExport void deserialize(
+                eprosima::fastcdr::Cdr& cdr,
+                CO2FootprintImpl& data)
+        {
+            cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+                    eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                    eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                    [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                                        case 0:
-                                                dcdr >> data.carbon_footprint();
-                                            break;
+                    case 0:
+                        dcdr >> data.carbon_footprint();
+                        break;
 
-                                        case 1:
-                                                dcdr >> data.energy_consumption();
-                                            break;
+                    case 1:
+                        dcdr >> data.energy_consumption();
+                        break;
 
-                                        case 2:
-                                                dcdr >> data.carbon_intensity();
-                                            break;
+                    case 2:
+                        dcdr >> data.carbon_intensity();
+                        break;
 
-                                        case 3:
-                                                dcdr >> data.extra_data();
-                                            break;
+                    case 3:
+                        dcdr >> data.extra_data();
+                        break;
 
-                                        case 4:
-                                                dcdr >> data.task_id();
-                                            break;
+                    case 4:
+                        dcdr >> data.task_id();
+                        break;
 
                     default:
                         ret_value = false;
@@ -1250,26 +1269,24 @@ eProsima_user_DllExport void deserialize(
                 }
                 return ret_value;
             });
-}
+        }
 
-void serialize_key(
-        eprosima::fastcdr::Cdr& scdr,
-        const CO2FootprintImpl& data)
-{
+        void serialize_key(
+                eprosima::fastcdr::Cdr& scdr,
+                const CO2FootprintImpl& data)
+        {
             extern void serialize_key(
                     Cdr& scdr,
                     const TaskIdImpl& data);
 
 
-    static_cast<void>(scdr);
-    static_cast<void>(data);
-                        serialize_key(scdr, data.task_id());
+            static_cast < void > (scdr);
+            static_cast < void > (data);
+            serialize_key(scdr, data.task_id());
 
-}
+        }
 
-
-
-} // namespace fastcdr
+    } // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_modules/test/communication/types/typesImplPubSubTypes.cxx
+++ b/sustainml_modules/test/communication/types/typesImplPubSubTypes.cxx
@@ -128,8 +128,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,7 +184,8 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -309,8 +310,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -365,7 +366,8 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -392,8 +394,6 @@ void NodeStatusImplPubSubType::register_type_object_representation()
 {
     register_NodeStatusImpl_type_identifier(type_identifiers_);
 }
-
-
 
 NodeControlImplPubSubType::NodeControlImplPubSubType()
 {
@@ -492,8 +492,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,7 +548,8 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -673,8 +674,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -729,7 +730,8 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -854,8 +856,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -910,7 +912,8 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -1035,8 +1038,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1091,7 +1094,8 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1216,8 +1220,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1272,7 +1276,8 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1397,8 +1402,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1453,7 +1458,8 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1578,8 +1584,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1634,7 +1640,8 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1759,8 +1766,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-                4u /*encapsulation*/;
+                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+               4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1815,7 +1822,8 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
+            eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1842,7 +1850,6 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
-
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_modules/test/communication/types/typesImplPubSubTypes.cxx
+++ b/sustainml_modules/test/communication/types/typesImplPubSubTypes.cxx
@@ -128,8 +128,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,8 +184,7 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -310,8 +309,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -366,8 +365,7 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -394,6 +392,8 @@ void NodeStatusImplPubSubType::register_type_object_representation()
 {
     register_NodeStatusImpl_type_identifier(type_identifiers_);
 }
+
+
 
 NodeControlImplPubSubType::NodeControlImplPubSubType()
 {
@@ -492,8 +492,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,8 +548,7 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -674,8 +673,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -730,8 +729,7 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -856,8 +854,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -912,8 +910,7 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -1038,8 +1035,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1094,8 +1091,7 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1220,8 +1216,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1276,8 +1272,7 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1402,8 +1397,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1458,8 +1453,7 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1584,8 +1578,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1640,8 +1634,7 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1766,8 +1759,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1822,8 +1815,7 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1850,6 +1842,7 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
+
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_modules/test/communication/types/typesImplTypeObjectSupport.cxx
+++ b/sustainml_modules/test/communication/types/typesImplTypeObjectSupport.cxx
@@ -43,8 +43,7 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -54,204 +53,151 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
-                        ann_custom_Status,
-                        type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
-                        detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
-                            member_ann_builtin_NODE_ERROR,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
-                            member_ann_builtin_NODE_IDLE,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
-                            member_ann_builtin_NODE_RUNNING,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
-                            flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_Status, header_Status,
-            literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
+                literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
-                type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "Status already registered in TypeObjectRegistry for a different type.");
+                "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_TaskStatus_type_identifier(
+}void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus =
-                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
-                        ann_custom_TaskStatus,
-                        type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
-            common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
-                            member_ann_builtin_TASK_WAITING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
-                            member_ann_builtin_TASK_ERROR,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
-                            member_ann_builtin_TASK_RUNNING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
-                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_TaskStatus, header_TaskStatus,
-            literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
+                literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
-                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_ErrorCode_type_identifier(
+}void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -261,72 +207,55 @@ void register_ErrorCode_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
-                        ann_custom_ErrorCode,
-                        type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
-                        detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR =
-                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
-                            member_ann_builtin_NO_ERROR,
-                            ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
-                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_ErrorCode, header_ErrorCode,
-            literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
+                literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
-                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
-                        ann_custom_TaskIdImpl,
-                        type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -334,8 +263,7 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -344,37 +272,28 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
-                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_problem_id,
-                                                              common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
-                            member_ann_builtin_problem_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
-                            detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -383,44 +302,32 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
-                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_iteration_id,
-                                                                common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
-                            member_ann_builtin_iteration_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
-                common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
-                        header_TaskIdImpl,
-                        member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
-                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -428,19 +335,16 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -448,119 +352,91 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-                ::register_Status_type_identifier(type_ids_node_status);
+            ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
-                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_node_status,
-                                                               common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
-                            member_ann_builtin_node_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
-                            detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-                ::register_TaskStatus_type_identifier(type_ids_task_status);
+            ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
-                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_task_status,
-                                                               common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
-                            member_ann_builtin_task_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
-                            detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-                ::register_ErrorCode_type_identifier(type_ids_error_code);
+            ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
-                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_error_code,
-                                                              common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
-                            member_ann_builtin_error_code,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
-                            detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -573,41 +449,32 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_error_description,
-                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_error_description,
-                                                                 common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
-                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
-                common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -620,23 +487,18 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
-                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_node_name,
-                                                             common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -647,46 +509,34 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
-                    hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
-                                min_node_name,
-                                max_node_name,
-                                hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
-                            member_ann_builtin_node_name,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
-                            detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -700,44 +550,33 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
-                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -747,101 +586,74 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
-                        ann_custom_CmdNode,
-                        type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
-                        detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
-                            member_ann_builtin_NO_CMD_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
-                            member_ann_builtin_START_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
-                            member_ann_builtin_STOP_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
-                            member_ann_builtin_RESET_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdNode, header_CmdNode,
-            literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
+                literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
-                type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdNode already registered in TypeObjectRegistry for a different type.");
+                "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_CmdTask_type_identifier(
+}void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -851,197 +663,149 @@ void register_CmdTask_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
-                        ann_custom_CmdTask,
-                        type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
-                        detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
-                            member_ann_builtin_NO_CMD_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
-                            member_ann_builtin_STOP_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
-                            member_ann_builtin_RESET_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
-                            member_ann_builtin_PREEMPT_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdTask, header_CmdTask,
-            literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
+                literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
-                type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdTask already registered in TypeObjectRegistry for a different type.");
+                "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl =
-                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-                ::register_CmdNode_type_identifier(type_ids_cmd_node);
+            ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
-                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_node,
-                                                            common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
-                            member_ann_builtin_cmd_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
-                            detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-                ::register_CmdTask_type_identifier(type_ids_cmd_task);
+            ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
-                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_task,
-                                                            common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
-                            member_ann_builtin_cmd_task,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
-                            detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -1054,41 +818,32 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
-                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_target_node,
-                                                               common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
-                            member_ann_builtin_target_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
-                            detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -1101,23 +856,18 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
-                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_source_node,
-                                                               common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -1128,44 +878,34 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
-                    hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
-                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
-                            member_ann_builtin_source_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
-                            detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1179,37 +919,27 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
-                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -1217,19 +947,16 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -1237,8 +964,7 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -1251,41 +977,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
-                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_modality,
-                                                            common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
-                            member_ann_builtin_modality,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
-                            detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1298,42 +1015,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
-                                                                     member_id_problem_short_description,
-                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                         type_ids_problem_short_description,
-                                                                         common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
-                name_problem_short_description, member_ann_builtin_problem_short_description,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
-                common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1346,48 +1053,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_problem_definition,
-                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_problem_definition,
-                                                                  common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
-                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
-                common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1400,15 +1097,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_inputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1420,34 +1114,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
-                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                          type_ids_inputs,
-                                                          common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1456,26 +1140,21 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
-                            member_ann_builtin_inputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
-                            detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1488,15 +1167,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_outputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1508,34 +1184,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
-                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_outputs,
-                                                           common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1544,19 +1210,15 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
-                            member_ann_builtin_outputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
-                            detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1565,36 +1227,28 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_minimum_samples,
-                                                               common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1603,36 +1257,28 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_maximum_samples,
-                                                               common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1641,42 +1287,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
-                                                                            member_id_optimize_carbon_footprint_manual,
-                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                type_ids_optimize_carbon_footprint_manual,
-                                                                                common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
-                            member_ann_builtin_optimize_carbon_footprint_manual,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
-                            detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1685,37 +1317,28 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_previous_iteration,
-                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_previous_iteration,
-                                                                  common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
-                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
-                common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1724,40 +1347,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
-                                                                          member_id_optimize_carbon_footprint_auto,
-                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                              type_ids_optimize_carbon_footprint_auto,
-                                                                              common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
-                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
-                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1766,38 +1377,28 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                    member_id_desired_carbon_footprint,
-                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                        type_ids_desired_carbon_footprint,
-                                                                        common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1810,41 +1411,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
-                                                                  member_id_geo_location_continent,
-                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                      type_ids_geo_location_continent,
-                                                                      common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1857,48 +1449,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
-                                                               member_id_geo_location_region,
-                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                   type_ids_geo_location_region,
-                                                                   common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1907,85 +1489,65 @@ void register_UserInputImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1999,37 +1561,27 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
-                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -2037,37 +1589,30 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
-            type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -2080,15 +1625,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_keywords,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2100,63 +1642,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
-                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_keywords,
-                                                            common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
-                            member_ann_builtin_keywords,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
-                            detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -2169,15 +1695,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_ml_model_metadata,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2189,63 +1712,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_ml_model_metadata,
-                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_ml_model_metadata,
-                                                                 common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
-                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
-                common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2254,85 +1761,65 @@ void register_MLModelMetadataImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2346,37 +1833,27 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
-                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -2384,37 +1861,30 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
-            type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -2427,15 +1897,12 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_app_requirements,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2447,62 +1914,47 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_app_requirements,
-                                                                common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
-                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
-                common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2511,85 +1963,65 @@ void register_AppRequirementsImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2603,37 +2035,27 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
-                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2641,30 +2063,24 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
-            type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2673,44 +2089,104 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                member_id_max_memory_footprint,
-                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                    type_ids_max_memory_footprint,
-                                                                    common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
+        }
+        {
+            TypeIdentifierPair type_ids_hardware_required;
+            ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_hardware_required =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
+            {
+                return_code_hardware_required =
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    "anonymous_string_unbounded", type_ids_hardware_required);
+
+                if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
+                {
+                    {
+                        SBound bound = 0;
+                        StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                                TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                                "anonymous_string_unbounded", type_ids_hardware_required))
+                        {
+                            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                        }
+                    }
+                }
+                bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
+                {
+                    EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
+                    return;
+                }
+                EquivalenceKind equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_COMPLETE;
+                if (TK_NONE == type_ids_hardware_required.type_identifier2()._d())
+                {
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
+                }
+                CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                {
+                    SBound bound = 0;
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_hardware_required = 0x00000001;
+            bool common_hardware_required_ec {false};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
+            if (!common_hardware_required_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_hardware_required = "hardware_required";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
+            ann_custom_HWConstraintsImpl.reset();
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
+            TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2719,85 +2195,65 @@ void register_HWConstraintsImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
-            MemberId member_id_extra_data = 0x00000001;
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
-            MemberId member_id_task_id = 0x00000002;
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2811,37 +2267,27 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
-                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2849,19 +2295,16 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2869,8 +2312,7 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2883,41 +2325,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
-                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_model_path,
-                                                              common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
-                            member_ann_builtin_model_path,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
-                            detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2930,19 +2363,15 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
-                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                         type_ids_model,
-                                                         common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2951,26 +2380,21 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
-                            member_ann_builtin_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model =
-                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_raw_model);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2979,70 +2403,54 @@ void register_MLModelImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_raw_model,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_raw_model.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
-                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_raw_model,
-                                                             common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
-                            member_ann_builtin_raw_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
-                            detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -3055,41 +2463,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
-                                                                 member_id_model_properties_path,
-                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                     type_ids_model_properties_path,
-                                                                     common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -3102,47 +2501,38 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_model_properties,
-                                                                common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -3155,15 +2545,12 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_input_batch,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3175,56 +2562,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
-                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_input_batch,
-                                                               common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
-                            member_ann_builtin_input_batch,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
-                            detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -3233,43 +2605,34 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_target_latency,
-                                                              common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
-                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
-                common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3278,85 +2641,65 @@ void register_MLModelImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3370,37 +2713,27 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
-                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -3408,19 +2741,16 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -3428,8 +2758,7 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -3442,40 +2771,32 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_hw_description,
-                                                              common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
-                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
-                common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -3484,37 +2805,28 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_power_consumption,
-                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_power_consumption,
-                                                                 common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -3523,15 +2835,11 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
-                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_latency,
-                                                           common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -3540,19 +2848,15 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
-                            member_ann_builtin_latency,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
-                            detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -3561,38 +2865,28 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
-                                                                        member_id_memory_footprint_of_ml_model,
-                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                            type_ids_memory_footprint_of_ml_model,
-                                                                            common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
-                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
-                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -3601,45 +2895,34 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                   member_id_max_hw_memory_footprint,
-                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                       type_ids_max_hw_memory_footprint,
-                                                                       common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3648,85 +2931,65 @@ void register_HWResourceImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3740,37 +3003,27 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
-                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3778,29 +3031,24 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3809,36 +3057,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_footprint,
-                                                                common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3847,37 +3087,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_energy_consumption,
-                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_energy_consumption,
-                                                                  common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3886,43 +3117,34 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_intensity,
-                                                                common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
-                "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data);
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3931,85 +3153,65 @@ void register_CO2FootprintImpl_type_identifier(
                             "Sequence element TypeIdentifier unknown to TypeObjectRegistry.");
                     return;
                 }
-                bool element_identifier_anonymous_sequence_uint8_t_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_uint8_t_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                     type_ids_extra_data,
-                                                                                                     element_identifier_anonymous_sequence_uint8_t_unbounded_ec))};
-                if (!element_identifier_anonymous_sequence_uint8_t_unbounded_ec)
+                bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
                     return;
                 }
-                EquivalenceKind equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_COMPLETE;
+                EquivalenceKind equiv_kind_anonymous_sequence_byte_unbounded = EK_COMPLETE;
                 if (TK_NONE == type_ids_extra_data.type_identifier2()._d())
                 {
-                    equiv_kind_anonymous_sequence_uint8_t_unbounded = EK_BOTH;
+                    equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
-                CollectionElementFlag element_flags_anonymous_sequence_uint8_t_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_uint8_t_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_uint8_t_unbounded,
-                                element_flags_anonymous_sequence_uint8_t_unbounded);
+                CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_uint8_t_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_uint8_t_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_uint8_t_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_uint8_t_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -4023,33 +3225,25 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
-                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+

--- a/sustainml_modules/test/communication/types/typesImplTypeObjectSupport.cxx
+++ b/sustainml_modules/test/communication/types/typesImplTypeObjectSupport.cxx
@@ -43,7 +43,8 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -53,151 +54,204 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
+                        ann_custom_Status,
+                        type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
+                        detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
+                            member_ann_builtin_NODE_ERROR,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
+                            member_ann_builtin_NODE_IDLE,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
+                            member_ann_builtin_NODE_RUNNING,
+                            ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
+                            flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
+                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
-                literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_Status, header_Status,
+            literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
+                type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "Status already registered in TypeObjectRegistry for a different type.");
+                    "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_TaskStatus_type_identifier(
+}
+
+void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus =
+                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
+                        ann_custom_TaskStatus,
+                        type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
+            common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
+                            member_ann_builtin_TASK_WAITING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
+                            member_ann_builtin_TASK_ERROR,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
+                            member_ann_builtin_TASK_RUNNING,
+                            ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
+                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
-                literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_TaskStatus, header_TaskStatus,
+            literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
+                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_ErrorCode_type_identifier(
+}
+
+void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -207,55 +261,72 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
+                        ann_custom_ErrorCode,
+                        type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
+                        detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR =
+                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
+                            member_ann_builtin_NO_ERROR,
+                            ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
+                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
+                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
-                literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_ErrorCode, header_ErrorCode,
+            literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
+                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
+                        ann_custom_TaskIdImpl,
+                        type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -263,7 +334,8 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -272,28 +344,37 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
+                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_problem_id,
+                                                              common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
+                            member_ann_builtin_problem_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
+                            detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -302,32 +383,44 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
+                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_iteration_id,
+                                                                common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
+                            member_ann_builtin_iteration_id,
+                            ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
+                common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
+                        header_TaskIdImpl,
+                        member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
+                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -335,16 +428,19 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -352,91 +448,119 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-            ::register_Status_type_identifier(type_ids_node_status);
+                ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
+                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_node_status,
+                                                               common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
+                            member_ann_builtin_node_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
+                            detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-            ::register_TaskStatus_type_identifier(type_ids_task_status);
+                ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
+                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_task_status,
+                                                               common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
+                            member_ann_builtin_task_status,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
+                            detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-            ::register_ErrorCode_type_identifier(type_ids_error_code);
+                ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
+                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_error_code,
+                                                              common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
+                            member_ann_builtin_error_code,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
+                            detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -449,32 +573,41 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_error_description,
+                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_error_description,
+                                                                 common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
+                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
+                common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -487,18 +620,23 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
+                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_node_name,
+                                                             common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -509,34 +647,46 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
+                    hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
+                                min_node_name,
+                                max_node_name,
+                                hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
+                            member_ann_builtin_node_name,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
+                            detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -550,33 +700,44 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
+                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -586,74 +747,101 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
+                        ann_custom_CmdNode,
+                        type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
+                        detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
+                            member_ann_builtin_NO_CMD_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
+                            member_ann_builtin_START_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
+                            member_ann_builtin_STOP_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
+                            member_ann_builtin_RESET_NODE,
+                            ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
-                literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdNode, header_CmdNode,
+            literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
+                type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdNode already registered in TypeObjectRegistry for a different type.");
+                    "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}void register_CmdTask_type_identifier(
+}
+
+void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -663,149 +851,197 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
+                        ann_custom_CmdTask,
+                        type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
+                        detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
+                            flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
+                            member_ann_builtin_NO_CMD_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
+                            flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
+                            member_ann_builtin_STOP_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
+                            flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
+                            member_ann_builtin_RESET_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
+                            flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
+                            member_ann_builtin_PREEMPT_TASK,
+                            ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
+                            flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
+                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
+                common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
-                literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
+            enum_flags_CmdTask, header_CmdTask,
+            literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
+                type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                "CmdTask already registered in TypeObjectRegistry for a different type.");
+                    "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl =
+                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-            ::register_CmdNode_type_identifier(type_ids_cmd_node);
+                ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
+                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_node,
+                                                            common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
+                            member_ann_builtin_cmd_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
+                            detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-            ::register_CmdTask_type_identifier(type_ids_cmd_task);
+                ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
+                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_cmd_task,
+                                                            common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
+                            member_ann_builtin_cmd_task,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
+                            detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -818,32 +1054,41 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
+                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_target_node,
+                                                               common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
+                            member_ann_builtin_target_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
+                            detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -856,18 +1101,23 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
+                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_source_node,
+                                                               common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -878,34 +1128,44 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
+                    hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
+                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
+                            member_ann_builtin_source_node,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
+                            detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -919,27 +1179,37 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
+                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -947,16 +1217,19 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -964,7 +1237,8 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -977,32 +1251,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
+                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_modality,
+                                                            common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
+                            member_ann_builtin_modality,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
+                            detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1015,32 +1298,42 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
+                                                                     member_id_problem_short_description,
+                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                         type_ids_problem_short_description,
+                                                                         common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
+                name_problem_short_description, member_ann_builtin_problem_short_description,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
+                common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1053,38 +1346,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_problem_definition,
+                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_problem_definition,
+                                                                  common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
+                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
+                common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1097,12 +1400,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_inputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1114,24 +1420,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
+                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                          type_ids_inputs,
+                                                          common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1140,21 +1456,26 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
+                            member_ann_builtin_inputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
+                            detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1167,12 +1488,15 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_outputs,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1184,24 +1508,34 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
+                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_outputs,
+                                                           common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1210,15 +1544,19 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
+                            member_ann_builtin_outputs,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
+                            detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1227,28 +1565,36 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_minimum_samples,
+                                                               common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1257,28 +1603,36 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
+                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_maximum_samples,
+                                                               common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
+                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
+                common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1287,28 +1641,42 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
+                                                                            member_id_optimize_carbon_footprint_manual,
+                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                type_ids_optimize_carbon_footprint_manual,
+                                                                                common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
+                            member_ann_builtin_optimize_carbon_footprint_manual,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual =
+                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
+                            detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1317,28 +1685,37 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_previous_iteration,
+                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_previous_iteration,
+                                                                  common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
+                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
+                common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1347,28 +1724,40 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
+                                                                          member_id_optimize_carbon_footprint_auto,
+                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                              type_ids_optimize_carbon_footprint_auto,
+                                                                              common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
+            member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
+                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
+                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
+                    member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1377,28 +1766,38 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                    member_id_desired_carbon_footprint,
+                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                        type_ids_desired_carbon_footprint,
+                                                                        common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
+                ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1411,32 +1810,41 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
+                                                                  member_id_geo_location_continent,
+                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                      type_ids_geo_location_continent,
+                                                                      common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1449,38 +1857,48 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
+                                                               member_id_geo_location_region,
+                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                   type_ids_geo_location_region,
+                                                                   common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
+                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
+                common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1490,7 +1908,9 @@ void register_UserInputImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1502,52 +1922,70 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1561,27 +1999,37 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
+                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -1589,30 +2037,37 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
+            type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -1625,12 +2080,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_keywords,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1642,47 +2100,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
+                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                            type_ids_keywords,
+                                                            common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
+                            member_ann_builtin_keywords,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
+                            detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -1695,12 +2169,15 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_ml_model_metadata,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1712,47 +2189,63 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_ml_model_metadata,
+                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_ml_model_metadata,
+                                                                 common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
+                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
+                common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1762,7 +2255,9 @@ void register_MLModelMetadataImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1774,52 +2269,70 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1833,27 +2346,37 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
+                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -1861,30 +2384,37 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
+            type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -1897,12 +2427,15 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_app_requirements,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1914,47 +2447,62 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_app_requirements,
+                                                                common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
+                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
+                common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1964,7 +2512,9 @@ void register_AppRequirementsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1976,52 +2526,70 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2035,27 +2603,37 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
+                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2063,24 +2641,30 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
+            type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2089,34 +2673,44 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                member_id_max_memory_footprint,
+                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                    type_ids_max_memory_footprint,
+                                                                    common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_hardware_required;
             ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hardware_required =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
             {
                 return_code_hardware_required =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_hardware_required);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
@@ -2129,12 +2723,15 @@ void register_HWConstraintsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_hardware_required))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_hardware_required,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2146,47 +2743,63 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_hardware_required = 0x00000001;
             bool common_hardware_required_ec {false};
-            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_hardware_required,
+                                                             member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_hardware_required,
+                                                                 common_hardware_required_ec))};
             if (!common_hardware_required_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure hardware_required member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hardware_required = "hardware_required";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(
+                name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(
+                common_hardware_required, detail_hardware_required);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2196,7 +2809,9 @@ void register_HWConstraintsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2208,52 +2823,70 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2267,27 +2900,37 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
+                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2295,16 +2938,19 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2312,7 +2958,8 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2325,32 +2972,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
+                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_model_path,
+                                                              common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
+                            member_ann_builtin_model_path,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
+                            detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -2363,15 +3019,19 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
+                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                         type_ids_model,
+                                                         common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -2380,21 +3040,26 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
+                            member_ann_builtin_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_model =
+                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -2404,7 +3069,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_raw_model,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2416,41 +3083,55 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
+                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                             type_ids_raw_model,
+                                                             common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
+                            member_ann_builtin_raw_model,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
+                            detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -2463,32 +3144,41 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
+                                                                 member_id_model_properties_path,
+                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                     type_ids_model_properties_path,
+                                                                     common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -2501,38 +3191,47 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_model_properties,
+                                                                common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
+                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
+                common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -2545,12 +3244,15 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
+                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                                        type_ids_input_batch,
+                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2562,41 +3264,56 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(
+                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
+                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
+                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                               type_ids_input_batch,
+                                                               common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
+                            member_ann_builtin_input_batch,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
+                            detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -2605,34 +3322,43 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_target_latency,
+                                                              common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
+                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
+                common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2642,7 +3368,9 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2654,52 +3382,70 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2713,27 +3459,37 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
+                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -2741,16 +3497,19 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -2758,7 +3517,8 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -2771,32 +3531,40 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
+                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_hw_description,
+                                                              common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
+                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
+                common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -2805,28 +3573,37 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
+                                                             member_id_power_consumption,
+                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                 type_ids_power_consumption,
+                                                                 common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -2835,11 +3612,15 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
+                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_latency,
+                                                           common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -2848,15 +3629,19 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
+                            member_ann_builtin_latency,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
+                            detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -2865,28 +3650,38 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
+                                                                        member_id_memory_footprint_of_ml_model,
+                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                            type_ids_memory_footprint_of_ml_model,
+                                                                            common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
+                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
+                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -2895,34 +3690,45 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
+                                                                   member_id_max_hw_memory_footprint,
+                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                       type_ids_max_hw_memory_footprint,
+                                                                       common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
+                ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2932,7 +3738,9 @@ void register_HWResourceImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2944,52 +3752,70 @@ void register_HWResourceImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3003,27 +3829,37 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
+                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3031,24 +3867,29 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                    get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-                false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
+            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+            false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
+            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
+            TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3057,28 +3898,36 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_footprint,
+                                                                common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3087,28 +3936,37 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
+                                                              member_id_energy_consumption,
+                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                  type_ids_energy_consumption,
+                                                                  common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
+                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
+                common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3117,34 +3975,43 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
+                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                type_ids_carbon_intensity,
+                                                                common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
+                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
+                common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                                get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3154,7 +4021,9 @@ void register_CO2FootprintImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
+                                                                                                  type_ids_extra_data,
+                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3166,52 +4035,70 @@ void register_CO2FootprintImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
+                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
+                                element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
-                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
+                        header_anonymous_sequence_byte_unbounded, bound,
+                        eprosima::fastcdr::external<TypeIdentifier>(
+                            element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
+                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
+                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                              type_ids_extra_data,
+                                                              common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
+                            member_ann_builtin_extra_data,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
+                            detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
+                            get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                    false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
+                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
+                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
+                                                           type_ids_task_id,
+                                                           common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3225,25 +4112,33 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
+                    hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
+                                min_task_id,
+                                max_task_id,
+                                hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
+                            member_ann_builtin_task_id,
+                            ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
+                            detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
+            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
+                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-

--- a/sustainml_py/examples/hw_constratins_node.py
+++ b/sustainml_py/examples/hw_constratins_node.py
@@ -36,6 +36,7 @@ def signal_handler(sig, frame):
 def task_callback(user_input, node_status, hw_constraints):
     print (user_input.problem_definition())
     hw_constraints.max_memory_footprint(100)
+    hw_constraints.hardware_required(['PIM_AI_1chip'])
 
 # Main workflow routine
 def run():

--- a/sustainml_py/examples/ml_model_node.py
+++ b/sustainml_py/examples/ml_model_node.py
@@ -47,7 +47,9 @@ def task_callback(
         print("Received metadata " + metadata)
     for requirement in app_requirements.app_requirements():
         print("Received app requirement " + requirement)
-    print ("Received HW constraints: Max memory footprint: " + str(hw_constraints.max_memory_footprint()) + " MB")
+    print ("Received HW constraints:\n  Max memory footprint: " + str(hw_constraints.max_memory_footprint()) + " MB")
+    for hw in hw_constraints.hardware_required():
+        print("  Hardware required: " + hw)
     print (node_status.node_status())
     ml_model.model("MODEL in ONXX format")
 

--- a/sustainml_swig/src/swig/sustainml_swig/nodes/OrchestratorNode.i
+++ b/sustainml_swig/src/swig/sustainml_swig/nodes/OrchestratorNode.i
@@ -30,7 +30,7 @@
 %{
 #include <sustainml_cpp/core/Constants.hpp>
 #include <sustainml_cpp/orchestrator/OrchestratorNode.hpp>
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 %}
 
 %feature("director") types::AppRequirements;
@@ -173,5 +173,5 @@
 %}
 
 // Include the class interfaces
-%include <sustainml_cpp/types/types.h>
+%include <sustainml_cpp/types/types.hpp>
 %include <sustainml_cpp/orchestrator/OrchestratorNode.hpp>

--- a/sustainml_swig/src/swig/sustainml_swig/types/types.i
+++ b/sustainml_swig/src/swig/sustainml_swig/types/types.i
@@ -28,8 +28,8 @@
 %ignore operator<<;
 
 %{
-#include <sustainml_cpp/types/types.h>
+#include <sustainml_cpp/types/types.hpp>
 %}
 
 // Include the class interfaces
-%include <sustainml_cpp/types/types.h>
+%include <sustainml_cpp/types/types.hpp>


### PR DESCRIPTION
This PR  updates idls, data types and their usage in the protect to include a new field `hardware_required` in the HWConstraints Node.

This PR is on top of (and must be merged after):
- #56 