### PR TITLE
Test for configuration_request on orchestrator node

### DIFF
--- a/sustainml_cpp/examples/CliModules/typesImpl.hpp
+++ b/sustainml_cpp/examples/CliModules/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-               m_iteration_id == x.m_iteration_id);
+           m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,6 +209,7 @@ public:
         return m_problem_id;
     }
 
+
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -236,6 +237,8 @@ public:
     {
         return m_iteration_id;
     }
+
+
 
 private:
 
@@ -272,17 +275,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -309,17 +312,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -349,11 +352,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-               m_task_status == x.m_task_status &&
-               m_error_code == x.m_error_code &&
-               m_error_description == x.m_error_description &&
-               m_node_name == x.m_node_name &&
-               m_task_id == x.m_task_id);
+           m_task_status == x.m_task_status &&
+           m_error_code == x.m_error_code &&
+           m_error_description == x.m_error_description &&
+           m_node_name == x.m_node_name &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -394,6 +397,7 @@ public:
         return m_node_status;
     }
 
+
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -422,6 +426,7 @@ public:
         return m_task_status;
     }
 
+
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -449,6 +454,7 @@ public:
     {
         return m_error_code;
     }
+
 
     /*!
      * @brief This function copies the value in member error_description
@@ -488,6 +494,7 @@ public:
         return m_error_description;
     }
 
+
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -526,6 +533,7 @@ public:
         return m_node_name;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -563,6 +571,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -627,15 +637,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -661,15 +671,15 @@ public:
             const NodeControlImpl& x)
     {
 
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -698,10 +708,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-               m_cmd_task == x.m_cmd_task &&
-               m_target_node == x.m_target_node &&
-               m_source_node == x.m_source_node &&
-               m_task_id == x.m_task_id);
+           m_cmd_task == x.m_cmd_task &&
+           m_target_node == x.m_target_node &&
+           m_source_node == x.m_source_node &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -742,6 +752,7 @@ public:
         return m_cmd_node;
     }
 
+
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -769,6 +780,7 @@ public:
     {
         return m_cmd_task;
     }
+
 
     /*!
      * @brief This function copies the value in member target_node
@@ -808,6 +820,7 @@ public:
         return m_target_node;
     }
 
+
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -845,6 +858,7 @@ public:
     {
         return m_source_node;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -884,6 +898,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -922,35 +938,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -986,35 +1002,35 @@ public:
             const UserInputImpl& x)
     {
 
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1053,20 +1069,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-               m_problem_short_description == x.m_problem_short_description &&
-               m_problem_definition == x.m_problem_definition &&
-               m_inputs == x.m_inputs &&
-               m_outputs == x.m_outputs &&
-               m_minimum_samples == x.m_minimum_samples &&
-               m_maximum_samples == x.m_maximum_samples &&
-               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-               m_previous_iteration == x.m_previous_iteration &&
-               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-               m_geo_location_continent == x.m_geo_location_continent &&
-               m_geo_location_region == x.m_geo_location_region &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_problem_short_description == x.m_problem_short_description &&
+           m_problem_definition == x.m_problem_definition &&
+           m_inputs == x.m_inputs &&
+           m_outputs == x.m_outputs &&
+           m_minimum_samples == x.m_minimum_samples &&
+           m_maximum_samples == x.m_maximum_samples &&
+           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+           m_previous_iteration == x.m_previous_iteration &&
+           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+           m_geo_location_continent == x.m_geo_location_continent &&
+           m_geo_location_region == x.m_geo_location_region &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1117,6 +1133,7 @@ public:
         return m_modality;
     }
 
+
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1154,6 +1171,7 @@ public:
     {
         return m_problem_short_description;
     }
+
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1193,6 +1211,7 @@ public:
         return m_problem_definition;
     }
 
+
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1230,6 +1249,7 @@ public:
     {
         return m_inputs;
     }
+
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1269,6 +1289,7 @@ public:
         return m_outputs;
     }
 
+
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1296,6 +1317,7 @@ public:
     {
         return m_minimum_samples;
     }
+
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1325,6 +1347,7 @@ public:
         return m_maximum_samples;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1352,6 +1375,7 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
+
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1381,6 +1405,7 @@ public:
         return m_previous_iteration;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1409,6 +1434,7 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
+
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1436,6 +1462,7 @@ public:
     {
         return m_desired_carbon_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1475,6 +1502,7 @@ public:
         return m_geo_location_continent;
     }
 
+
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1512,6 +1540,7 @@ public:
     {
         return m_geo_location_region;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1551,6 +1580,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1588,6 +1618,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -1637,13 +1669,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1668,13 +1700,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1702,9 +1734,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-               m_ml_model_metadata == x.m_ml_model_metadata &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_ml_model_metadata == x.m_ml_model_metadata &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1755,6 +1787,7 @@ public:
         return m_keywords;
     }
 
+
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1792,6 +1825,7 @@ public:
     {
         return m_ml_model_metadata;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1831,6 +1865,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1869,6 +1904,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_keywords;
@@ -1906,11 +1943,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1934,11 +1971,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1965,8 +2002,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2017,6 +2054,7 @@ public:
         return m_app_requirements;
     }
 
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2054,6 +2092,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2093,6 +2132,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2129,13 +2170,13 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_hardware_required = x.m_hardware_required;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2160,13 +2201,13 @@ public:
             const HWConstraintsImpl& x)
     {
 
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_hardware_required = x.m_hardware_required;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2194,9 +2235,9 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-               m_hardware_required == x.m_hardware_required &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_hardware_required == x.m_hardware_required &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2237,6 +2278,7 @@ public:
         return m_max_memory_footprint;
     }
 
+
     /*!
      * @brief This function copies the value in member hardware_required
      * @param _hardware_required New value to be copied in member hardware_required
@@ -2274,6 +2316,7 @@ public:
     {
         return m_hardware_required;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2313,6 +2356,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2351,6 +2395,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     uint32_t m_max_memory_footprint{0};
@@ -2388,23 +2434,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2434,23 +2480,23 @@ public:
             const MLModelImpl& x)
     {
 
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2483,14 +2529,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-               m_model == x.m_model &&
-               m_raw_model == x.m_raw_model &&
-               m_model_properties_path == x.m_model_properties_path &&
-               m_model_properties == x.m_model_properties &&
-               m_input_batch == x.m_input_batch &&
-               m_target_latency == x.m_target_latency &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_model == x.m_model &&
+           m_raw_model == x.m_raw_model &&
+           m_model_properties_path == x.m_model_properties_path &&
+           m_model_properties == x.m_model_properties &&
+           m_input_batch == x.m_input_batch &&
+           m_target_latency == x.m_target_latency &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2541,6 +2587,7 @@ public:
         return m_model_path;
     }
 
+
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2578,6 +2625,7 @@ public:
     {
         return m_model;
     }
+
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2617,6 +2665,7 @@ public:
         return m_raw_model;
     }
 
+
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2654,6 +2703,7 @@ public:
     {
         return m_model_properties_path;
     }
+
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2693,6 +2743,7 @@ public:
         return m_model_properties;
     }
 
+
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2731,6 +2782,7 @@ public:
         return m_input_batch;
     }
 
+
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2758,6 +2810,7 @@ public:
     {
         return m_target_latency;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2797,6 +2850,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2834,6 +2888,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -2877,19 +2933,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2917,19 +2973,19 @@ public:
             const HWResourceImpl& x)
     {
 
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2960,12 +3016,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-               m_power_consumption == x.m_power_consumption &&
-               m_latency == x.m_latency &&
-               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_power_consumption == x.m_power_consumption &&
+           m_latency == x.m_latency &&
+           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3016,6 +3072,7 @@ public:
         return m_hw_description;
     }
 
+
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -3043,6 +3100,7 @@ public:
     {
         return m_power_consumption;
     }
+
 
     /*!
      * @brief This function sets a value in member latency
@@ -3072,6 +3130,7 @@ public:
         return m_latency;
     }
 
+
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3100,6 +3159,7 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
+
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3127,6 +3187,7 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3166,6 +3227,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3203,6 +3265,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -3244,15 +3308,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -3278,15 +3342,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3315,10 +3379,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-               m_energy_consumption == x.m_energy_consumption &&
-               m_carbon_intensity == x.m_carbon_intensity &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_energy_consumption == x.m_energy_consumption &&
+           m_carbon_intensity == x.m_carbon_intensity &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3359,6 +3423,7 @@ public:
         return m_carbon_footprint;
     }
 
+
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3387,6 +3452,7 @@ public:
         return m_energy_consumption;
     }
 
+
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3414,6 +3480,7 @@ public:
     {
         return m_carbon_intensity;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3453,6 +3520,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3490,6 +3558,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.hpp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.hpp
@@ -73,8 +73,6 @@ eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data);
 
-
-
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data);

--- a/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
+++ b/sustainml_cpp/examples/CliModules/typesImplCdrAux.ipp
@@ -34,29 +34,27 @@ using namespace eprosima::fastcdr::exception;
 namespace eprosima {
 namespace fastcdr {
 
-template < >
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const TaskIdImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.problem_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.problem_id(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.iteration_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.iteration_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -64,13 +62,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const TaskIdImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -79,11 +76,11 @@ eProsima_user_DllExport void serialize(
     scdr
         << eprosima::fastcdr::MemberId(0) << data.problem_id()
         << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         TaskIdImpl& data)
@@ -91,18 +88,18 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.problem_id();
-                        break;
+                                        case 0:
+                                                dcdr >> data.problem_id();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.iteration_id();
-                        break;
+                                        case 1:
+                                                dcdr >> data.iteration_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -117,49 +114,48 @@ void serialize_key(
         const TaskIdImpl& data)
 {
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    scdr << data.problem_id();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.problem_id();
 
-    scdr << data.iteration_id();
+                        scdr << data.iteration_id();
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const NodeStatusImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.node_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.task_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.task_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.error_code(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.error_code(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.error_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.error_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.node_name(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.node_name(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -167,13 +163,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -186,11 +181,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(3) << data.error_description()
         << eprosima::fastcdr::MemberId(4) << data.node_name()
         << eprosima::fastcdr::MemberId(5) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         NodeStatusImpl& data)
@@ -198,34 +193,34 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.node_status();
-                        break;
+                                        case 0:
+                                                dcdr >> data.node_status();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.task_status();
-                        break;
+                                        case 1:
+                                                dcdr >> data.task_status();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.error_code();
-                        break;
+                                        case 2:
+                                                dcdr >> data.error_code();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.error_description();
-                        break;
+                                        case 3:
+                                                dcdr >> data.error_description();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.node_name();
-                        break;
+                                        case 4:
+                                                dcdr >> data.node_name();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 5:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -239,51 +234,50 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    scdr << data.node_name();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.node_name();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const NodeControlImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.cmd_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.cmd_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.cmd_task(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.cmd_task(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.target_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.target_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.source_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.source_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -291,13 +285,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -309,11 +302,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.target_node()
         << eprosima::fastcdr::MemberId(3) << data.source_node()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         NodeControlImpl& data)
@@ -321,30 +314,30 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.cmd_node();
-                        break;
+                                        case 0:
+                                                dcdr >> data.cmd_node();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.cmd_task();
-                        break;
+                                        case 1:
+                                                dcdr >> data.cmd_task();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.target_node();
-                        break;
+                                        case 2:
+                                                dcdr >> data.target_node();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.source_node();
-                        break;
+                                        case 3:
+                                                dcdr >> data.source_node();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -358,81 +351,80 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    scdr << data.source_node();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.source_node();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const UserInputImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.modality(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.modality(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.problem_short_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.problem_short_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.problem_definition(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.problem_definition(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.inputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.inputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.outputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.outputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.minimum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.minimum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.maximum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.maximum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.optimize_carbon_footprint_manual(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.optimize_carbon_footprint_manual(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.previous_iteration(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.previous_iteration(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                    data.optimize_carbon_footprint_auto(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                data.optimize_carbon_footprint_auto(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                    data.desired_carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                data.desired_carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                    data.geo_location_continent(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                data.geo_location_continent(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                    data.geo_location_region(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                data.geo_location_region(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -440,13 +432,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const UserInputImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -468,11 +459,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
         << eprosima::fastcdr::MemberId(13) << data.extra_data()
         << eprosima::fastcdr::MemberId(14) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         UserInputImpl& data)
@@ -480,70 +471,70 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.modality();
-                        break;
+                                        case 0:
+                                                dcdr >> data.modality();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.problem_short_description();
-                        break;
+                                        case 1:
+                                                dcdr >> data.problem_short_description();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.problem_definition();
-                        break;
+                                        case 2:
+                                                dcdr >> data.problem_definition();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.inputs();
-                        break;
+                                        case 3:
+                                                dcdr >> data.inputs();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.outputs();
-                        break;
+                                        case 4:
+                                                dcdr >> data.outputs();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.minimum_samples();
-                        break;
+                                        case 5:
+                                                dcdr >> data.minimum_samples();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.maximum_samples();
-                        break;
+                                        case 6:
+                                                dcdr >> data.maximum_samples();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.optimize_carbon_footprint_manual();
-                        break;
+                                        case 7:
+                                                dcdr >> data.optimize_carbon_footprint_manual();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.previous_iteration();
-                        break;
+                                        case 8:
+                                                dcdr >> data.previous_iteration();
+                                            break;
 
-                    case 9:
-                        dcdr >> data.optimize_carbon_footprint_auto();
-                        break;
+                                        case 9:
+                                                dcdr >> data.optimize_carbon_footprint_auto();
+                                            break;
 
-                    case 10:
-                        dcdr >> data.desired_carbon_footprint();
-                        break;
+                                        case 10:
+                                                dcdr >> data.desired_carbon_footprint();
+                                            break;
 
-                    case 11:
-                        dcdr >> data.geo_location_continent();
-                        break;
+                                        case 11:
+                                                dcdr >> data.geo_location_continent();
+                                            break;
 
-                    case 12:
-                        dcdr >> data.geo_location_region();
-                        break;
+                                        case 12:
+                                                dcdr >> data.geo_location_region();
+                                            break;
 
-                    case 13:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 13:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 14:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 14:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -557,46 +548,45 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UserInputImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const MLModelMetadataImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.keywords(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.keywords(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.ml_model_metadata(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.ml_model_metadata(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -604,13 +594,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelMetadataImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -621,11 +610,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
         << eprosima::fastcdr::MemberId(2) << data.extra_data()
         << eprosima::fastcdr::MemberId(3) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         MLModelMetadataImpl& data)
@@ -633,26 +622,26 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.keywords();
-                        break;
+                                        case 0:
+                                                dcdr >> data.keywords();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.ml_model_metadata();
-                        break;
+                                        case 1:
+                                                dcdr >> data.ml_model_metadata();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -666,43 +655,42 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelMetadataImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const AppRequirementsImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.app_requirements(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.app_requirements(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -710,13 +698,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const AppRequirementsImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -726,11 +713,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(0) << data.app_requirements()
         << eprosima::fastcdr::MemberId(1) << data.extra_data()
         << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         AppRequirementsImpl& data)
@@ -738,22 +725,22 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.app_requirements();
-                        break;
+                                        case 0:
+                                                dcdr >> data.app_requirements();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -767,46 +754,45 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppRequirementsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const HWConstraintsImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.max_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.max_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.hardware_required(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.hardware_required(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -814,13 +800,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const HWConstraintsImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -831,11 +816,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.hardware_required()
         << eprosima::fastcdr::MemberId(2) << data.extra_data()
         << eprosima::fastcdr::MemberId(3) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         HWConstraintsImpl& data)
@@ -843,26 +828,26 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.max_memory_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.max_memory_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.hardware_required();
-                        break;
+                                        case 1:
+                                                dcdr >> data.hardware_required();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -876,61 +861,60 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWConstraintsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const MLModelImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.model_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.model_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.raw_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.raw_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.model_properties_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.model_properties_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.model_properties(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.model_properties(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.input_batch(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.input_batch(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.target_latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.target_latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -938,13 +922,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -960,11 +943,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(6) << data.target_latency()
         << eprosima::fastcdr::MemberId(7) << data.extra_data()
         << eprosima::fastcdr::MemberId(8) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         MLModelImpl& data)
@@ -972,46 +955,46 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.model_path();
-                        break;
+                                        case 0:
+                                                dcdr >> data.model_path();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.model();
-                        break;
+                                        case 1:
+                                                dcdr >> data.model();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.raw_model();
-                        break;
+                                        case 2:
+                                                dcdr >> data.raw_model();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.model_properties_path();
-                        break;
+                                        case 3:
+                                                dcdr >> data.model_properties_path();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.model_properties();
-                        break;
+                                        case 4:
+                                                dcdr >> data.model_properties();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.input_batch();
-                        break;
+                                        case 5:
+                                                dcdr >> data.input_batch();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.target_latency();
-                        break;
+                                        case 6:
+                                                dcdr >> data.target_latency();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 7:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 8:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1025,55 +1008,54 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const HWResourceImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.hw_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.hw_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.power_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.power_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.memory_footprint_of_ml_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.memory_footprint_of_ml_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.max_hw_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.max_hw_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1081,13 +1063,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const HWResourceImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -1101,11 +1082,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
         << eprosima::fastcdr::MemberId(5) << data.extra_data()
         << eprosima::fastcdr::MemberId(6) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         HWResourceImpl& data)
@@ -1113,38 +1094,38 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.hw_description();
-                        break;
+                                        case 0:
+                                                dcdr >> data.hw_description();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.power_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.power_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.latency();
-                        break;
+                                        case 2:
+                                                dcdr >> data.latency();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.memory_footprint_of_ml_model();
-                        break;
+                                        case 3:
+                                                dcdr >> data.memory_footprint_of_ml_model();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.max_hw_memory_footprint();
-                        break;
+                                        case 4:
+                                                dcdr >> data.max_hw_memory_footprint();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 5:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 6:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1158,49 +1139,48 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWResourceImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const CO2FootprintImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.energy_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.energy_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.carbon_intensity(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.carbon_intensity(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1208,13 +1188,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -1226,11 +1205,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
         << eprosima::fastcdr::MemberId(3) << data.extra_data()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         CO2FootprintImpl& data)
@@ -1238,30 +1217,30 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.carbon_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.carbon_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.energy_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.energy_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.carbon_intensity();
-                        break;
+                                        case 2:
+                                                dcdr >> data.carbon_intensity();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 3:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1275,18 +1254,20 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-}     // namespace fastcdr
+
+
+} // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool TaskIdImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -128,8 +129,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,8 +185,7 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -258,6 +258,7 @@ bool NodeStatusImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -310,8 +311,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -366,8 +367,7 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -440,6 +440,7 @@ bool NodeControlImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -492,8 +493,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,8 +549,7 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -622,6 +622,7 @@ bool UserInputImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -674,8 +675,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -730,8 +731,7 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -804,6 +804,7 @@ bool MLModelMetadataImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -856,8 +857,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -912,8 +913,7 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -986,6 +986,7 @@ bool AppRequirementsImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1038,8 +1039,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1094,8 +1095,7 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1168,6 +1168,7 @@ bool HWConstraintsImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1220,8 +1221,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1276,8 +1277,7 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1350,6 +1350,7 @@ bool MLModelImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1402,8 +1403,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1458,8 +1459,7 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1532,6 +1532,7 @@ bool HWResourceImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1584,8 +1585,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1640,8 +1641,7 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1714,6 +1714,7 @@ bool CO2FootprintImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1766,8 +1767,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1822,8 +1823,7 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1850,6 +1850,7 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
+
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.hpp
+++ b/sustainml_cpp/examples/CliModules/typesImplPubSubTypes.hpp
@@ -200,8 +200,6 @@ private:
 
 };
 
-
-
 /*!
  * @brief This class represents the TopicDataType of the type NodeControlImpl defined by the user in the IDL file.
  * @ingroup typesImpl

--- a/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/examples/CliModules/typesImplTypeObjectSupport.cxx
@@ -43,8 +43,7 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -54,204 +53,151 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
-                        ann_custom_Status,
-                        type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
-                        detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
-                            member_ann_builtin_NODE_ERROR,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
-                            member_ann_builtin_NODE_IDLE,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
-                            member_ann_builtin_NODE_RUNNING,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
-                            flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_Status, header_Status,
-            literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
+                literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
-                type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "Status already registered in TypeObjectRegistry for a different type.");
+                "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_TaskStatus_type_identifier(
+}void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus =
-                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
-                        ann_custom_TaskStatus,
-                        type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
-            common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
-                            member_ann_builtin_TASK_WAITING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
-                            member_ann_builtin_TASK_ERROR,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
-                            member_ann_builtin_TASK_RUNNING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
-                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_TaskStatus, header_TaskStatus,
-            literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
+                literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
-                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_ErrorCode_type_identifier(
+}void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -261,72 +207,55 @@ void register_ErrorCode_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
-                        ann_custom_ErrorCode,
-                        type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
-                        detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR =
-                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
-                            member_ann_builtin_NO_ERROR,
-                            ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
-                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_ErrorCode, header_ErrorCode,
-            literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
+                literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
-                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
-                        ann_custom_TaskIdImpl,
-                        type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -334,8 +263,7 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -344,37 +272,28 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
-                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_problem_id,
-                                                              common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
-                            member_ann_builtin_problem_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
-                            detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -383,44 +302,32 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
-                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_iteration_id,
-                                                                common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
-                            member_ann_builtin_iteration_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
-                common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
-                        header_TaskIdImpl,
-                        member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
-                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -428,19 +335,16 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -448,119 +352,91 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-                ::register_Status_type_identifier(type_ids_node_status);
+            ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
-                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_node_status,
-                                                               common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
-                            member_ann_builtin_node_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
-                            detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-                ::register_TaskStatus_type_identifier(type_ids_task_status);
+            ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
-                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_task_status,
-                                                               common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
-                            member_ann_builtin_task_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
-                            detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-                ::register_ErrorCode_type_identifier(type_ids_error_code);
+            ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
-                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_error_code,
-                                                              common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
-                            member_ann_builtin_error_code,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
-                            detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -573,41 +449,32 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_error_description,
-                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_error_description,
-                                                                 common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
-                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
-                common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -620,23 +487,18 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
-                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_node_name,
-                                                             common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -647,46 +509,34 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
-                    hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
-                                min_node_name,
-                                max_node_name,
-                                hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
-                            member_ann_builtin_node_name,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
-                            detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -700,44 +550,33 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
-                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -747,101 +586,74 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
-                        ann_custom_CmdNode,
-                        type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
-                        detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
-                            member_ann_builtin_NO_CMD_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
-                            member_ann_builtin_START_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
-                            member_ann_builtin_STOP_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
-                            member_ann_builtin_RESET_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdNode, header_CmdNode,
-            literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
+                literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
-                type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdNode already registered in TypeObjectRegistry for a different type.");
+                "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_CmdTask_type_identifier(
+}void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -851,197 +663,149 @@ void register_CmdTask_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
-                        ann_custom_CmdTask,
-                        type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
-                        detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
-                            member_ann_builtin_NO_CMD_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
-                            member_ann_builtin_STOP_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
-                            member_ann_builtin_RESET_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
-                            member_ann_builtin_PREEMPT_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdTask, header_CmdTask,
-            literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
+                literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
-                type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdTask already registered in TypeObjectRegistry for a different type.");
+                "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl =
-                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-                ::register_CmdNode_type_identifier(type_ids_cmd_node);
+            ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
-                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_node,
-                                                            common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
-                            member_ann_builtin_cmd_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
-                            detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-                ::register_CmdTask_type_identifier(type_ids_cmd_task);
+            ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
-                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_task,
-                                                            common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
-                            member_ann_builtin_cmd_task,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
-                            detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -1054,41 +818,32 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
-                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_target_node,
-                                                               common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
-                            member_ann_builtin_target_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
-                            detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -1101,23 +856,18 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
-                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_source_node,
-                                                               common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -1128,44 +878,34 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
-                    hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
-                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
-                            member_ann_builtin_source_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
-                            detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1179,37 +919,27 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
-                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -1217,19 +947,16 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -1237,8 +964,7 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -1251,41 +977,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
-                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_modality,
-                                                            common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
-                            member_ann_builtin_modality,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
-                            detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1298,42 +1015,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
-                                                                     member_id_problem_short_description,
-                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                         type_ids_problem_short_description,
-                                                                         common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
-                name_problem_short_description, member_ann_builtin_problem_short_description,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
-                common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1346,48 +1053,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_problem_definition,
-                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_problem_definition,
-                                                                  common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
-                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
-                common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1400,15 +1097,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_inputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1420,34 +1114,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
-                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                          type_ids_inputs,
-                                                          common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1456,26 +1140,21 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
-                            member_ann_builtin_inputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
-                            detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1488,15 +1167,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_outputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1508,34 +1184,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
-                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_outputs,
-                                                           common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1544,19 +1210,15 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
-                            member_ann_builtin_outputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
-                            detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1565,36 +1227,28 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_minimum_samples,
-                                                               common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1603,36 +1257,28 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_maximum_samples,
-                                                               common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1641,42 +1287,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
-                                                                            member_id_optimize_carbon_footprint_manual,
-                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                type_ids_optimize_carbon_footprint_manual,
-                                                                                common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
-                            member_ann_builtin_optimize_carbon_footprint_manual,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
-                            detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1685,37 +1317,28 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_previous_iteration,
-                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_previous_iteration,
-                                                                  common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
-                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
-                common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1724,40 +1347,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
-                                                                          member_id_optimize_carbon_footprint_auto,
-                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                              type_ids_optimize_carbon_footprint_auto,
-                                                                              common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
-                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
-                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1766,38 +1377,28 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                    member_id_desired_carbon_footprint,
-                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                        type_ids_desired_carbon_footprint,
-                                                                        common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1810,41 +1411,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
-                                                                  member_id_geo_location_continent,
-                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                      type_ids_geo_location_continent,
-                                                                      common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1857,48 +1449,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
-                                                               member_id_geo_location_region,
-                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                   type_ids_geo_location_region,
-                                                                   common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1908,9 +1490,7 @@ void register_UserInputImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1922,70 +1502,52 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1999,37 +1561,27 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
-                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -2037,37 +1589,30 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
-            type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -2080,15 +1625,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_keywords,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2100,63 +1642,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
-                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_keywords,
-                                                            common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
-                            member_ann_builtin_keywords,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
-                            detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -2169,15 +1695,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_ml_model_metadata,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2189,63 +1712,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_ml_model_metadata,
-                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_ml_model_metadata,
-                                                                 common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
-                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
-                common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2255,9 +1762,7 @@ void register_MLModelMetadataImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2269,70 +1774,52 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2346,37 +1833,27 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
-                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -2384,37 +1861,30 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
-            type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -2427,15 +1897,12 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_app_requirements,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2447,62 +1914,47 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_app_requirements,
-                                                                common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
-                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
-                common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2512,9 +1964,7 @@ void register_AppRequirementsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2526,70 +1976,52 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2603,37 +2035,27 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
-                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2641,30 +2063,24 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
-            type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2673,44 +2089,34 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                member_id_max_memory_footprint,
-                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                    type_ids_max_memory_footprint,
-                                                                    common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_hardware_required;
             ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hardware_required =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
             {
                 return_code_hardware_required =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_hardware_required);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
@@ -2723,15 +2129,12 @@ void register_HWConstraintsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_hardware_required))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_hardware_required,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2743,63 +2146,47 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hardware_required = 0x00000001;
             bool common_hardware_required_ec {false};
-            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_hardware_required,
-                                                             member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_hardware_required,
-                                                                 common_hardware_required_ec))};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
             if (!common_hardware_required_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hardware_required member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hardware_required = "hardware_required";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(
-                name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(
-                common_hardware_required, detail_hardware_required);
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2809,9 +2196,7 @@ void register_HWConstraintsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2823,70 +2208,52 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2900,37 +2267,27 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
-                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2938,19 +2295,16 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2958,8 +2312,7 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2972,41 +2325,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
-                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_model_path,
-                                                              common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
-                            member_ann_builtin_model_path,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
-                            detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -3019,19 +2363,15 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
-                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                         type_ids_model,
-                                                         common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -3040,26 +2380,21 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
-                            member_ann_builtin_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model =
-                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -3069,9 +2404,7 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_raw_model,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3083,55 +2416,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
-                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_raw_model,
-                                                             common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
-                            member_ann_builtin_raw_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
-                            detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -3144,41 +2463,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
-                                                                 member_id_model_properties_path,
-                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                     type_ids_model_properties_path,
-                                                                     common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -3191,47 +2501,38 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_model_properties,
-                                                                common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -3244,15 +2545,12 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_input_batch,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3264,56 +2562,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
-                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_input_batch,
-                                                               common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
-                            member_ann_builtin_input_batch,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
-                            detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -3322,43 +2605,34 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_target_latency,
-                                                              common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
-                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
-                common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3368,9 +2642,7 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3382,70 +2654,52 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3459,37 +2713,27 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
-                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -3497,19 +2741,16 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -3517,8 +2758,7 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -3531,40 +2771,32 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_hw_description,
-                                                              common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
-                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
-                common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -3573,37 +2805,28 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_power_consumption,
-                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_power_consumption,
-                                                                 common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -3612,15 +2835,11 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
-                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_latency,
-                                                           common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -3629,19 +2848,15 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
-                            member_ann_builtin_latency,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
-                            detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -3650,38 +2865,28 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
-                                                                        member_id_memory_footprint_of_ml_model,
-                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                            type_ids_memory_footprint_of_ml_model,
-                                                                            common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
-                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
-                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -3690,45 +2895,34 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                   member_id_max_hw_memory_footprint,
-                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                       type_ids_max_hw_memory_footprint,
-                                                                       common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3738,9 +2932,7 @@ void register_HWResourceImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3752,70 +2944,52 @@ void register_HWResourceImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3829,37 +3003,27 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
-                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3867,29 +3031,24 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3898,36 +3057,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_footprint,
-                                                                common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3936,37 +3087,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_energy_consumption,
-                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_energy_consumption,
-                                                                  common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3975,43 +3117,34 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_intensity,
-                                                                common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -4021,9 +3154,7 @@ void register_CO2FootprintImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -4035,70 +3166,52 @@ void register_CO2FootprintImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -4112,33 +3225,25 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
-                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+

--- a/sustainml_cpp/include/sustainml_cpp/idl/typesImpl.idl
+++ b/sustainml_cpp/include/sustainml_cpp/idl/typesImpl.idl
@@ -135,3 +135,19 @@ struct CO2FootprintImpl
     sequence<octet> extra_data;
     @key TaskIdImpl task_id;
 };
+
+struct RequestTypeImpl
+{
+    @key long node_id;
+    @key long transaction_id;
+    string configuration;
+};
+
+struct ResponseTypeImpl
+{
+    @key long node_id;
+    @key long transaction_id;
+    boolean success;
+    ErrorCode err_code;
+    string configuration;
+};

--- a/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
@@ -174,6 +174,15 @@ public:
     void send_control_command(
             const types::NodeControl& cmd);
 
+     /**
+     * @brief This method sends a request to node via service for changing its configuration.
+     * @param [in] req configuration request, contain which node and configuration file
+     * @param [out] res response from the node with its new configuration
+     */
+    bool configuration_request(
+            const types::RequestType req,
+            const types::ResponseType& res);
+
     /**
      * @brief Public method to get the mutex in order to correctly synchronise user
      * handle calls.

--- a/sustainml_cpp/include/sustainml_cpp/types/types.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/types/types.hpp
@@ -75,6 +75,8 @@ class NodeControlImpl;
 class NodeStatusImpl;
 class TaskIdImpl;
 class UserInputImpl;
+class RequestTypeImpl;
+class ResponseTypeImpl;
 
 enum class Status : int32_t;
 enum class TaskStatus : int32_t;
@@ -2382,6 +2384,340 @@ protected:
 
     UserInputImpl* impl_;
     friend class UserInputImpl;
+
+};
+
+/*!
+ * @brief This class represents the structure RequestType defined by the user in the IDL file.
+ * @ingroup types
+ */
+class RequestType
+{
+public:
+
+    using impl_type = RequestTypeImpl;
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport RequestType();
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~RequestType();
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object RequestType that will be copied.
+     */
+    eProsima_user_DllExport RequestType(
+            const RequestType& x);
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object RequestType that will be copied.
+     */
+    eProsima_user_DllExport RequestType(
+            RequestType&& x) noexcept;
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object RequestType that will be copied.
+     */
+    eProsima_user_DllExport RequestType& operator =(
+            const RequestType& x);
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object RequestType that will be copied.
+     */
+    eProsima_user_DllExport RequestType& operator =(
+            RequestType&& x) noexcept;
+
+    /*!
+     * @brief Comparison operator.
+     * @param x RequestType object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const RequestType& x) const;
+
+    /*!
+     * @brief Comparison operator.
+     * @param x RequestType object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const RequestType& x) const;
+
+    /*!
+     * @brief This function sets a value in member node_id
+     * @param _node_id New value for member node_id
+     */
+    eProsima_user_DllExport void node_id(
+            int32_t _node_id);
+
+    /*!
+     * @brief This function returns the value of member node_id
+     * @return Value of member node_id
+     */
+    eProsima_user_DllExport int32_t node_id() const;
+
+    /*!
+     * @brief This function returns a reference to member node_id
+     * @return Reference to member node_id
+     */
+    eProsima_user_DllExport int32_t& node_id();
+
+
+    /*!
+     * @brief This function sets a value in member transaction_id
+     * @param _transaction_id New value for member transaction_id
+     */
+    eProsima_user_DllExport void transaction_id(
+            int32_t _transaction_id);
+
+    /*!
+     * @brief This function returns the value of member transaction_id
+     * @return Value of member transaction_id
+     */
+    eProsima_user_DllExport int32_t transaction_id() const;
+
+    /*!
+     * @brief This function returns a reference to member transaction_id
+     * @return Reference to member transaction_id
+     */
+    eProsima_user_DllExport int32_t& transaction_id();
+
+
+    /*!
+     * @brief This function copies the value in member configuration
+     * @param _configuration New value to be copied in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            const std::string& _configuration);
+
+    /*!
+     * @brief This function moves the value in member configuration
+     * @param _configuration New value to be moved in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            std::string&& _configuration);
+
+    /*!
+     * @brief This function returns a constant reference to member configuration
+     * @return Constant reference to member configuration
+     */
+    eProsima_user_DllExport const std::string& configuration() const;
+
+    /*!
+     * @brief This function returns a reference to member configuration
+     * @return Reference to member configuration
+     */
+    eProsima_user_DllExport std::string& configuration();
+
+    /*!
+     * @brief This function returns the implementation
+     * @return Pointer to implementation
+     */
+    RequestTypeImpl* get_impl();
+
+    /*!
+     * @brief This function retrives the implementation type info
+     * @return Reference to the typeid
+     */
+    static const std::type_info& impl_typeinfo();
+
+protected:
+
+    RequestTypeImpl* impl_;
+    friend class RequestTypeImpl;
+
+};
+
+/*!
+ * @brief This class represents the structure ResponseType defined by the user in the IDL file.
+ * @ingroup types
+ */
+class ResponseType
+{
+public:
+
+    using impl_type = ResponseTypeImpl;
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport ResponseType();
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~ResponseType();
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object ResponseType that will be copied.
+     */
+    eProsima_user_DllExport ResponseType(
+            const ResponseType& x);
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object ResponseType that will be copied.
+     */
+    eProsima_user_DllExport ResponseType(
+            ResponseType&& x) noexcept;
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object ResponseType that will be copied.
+     */
+    eProsima_user_DllExport ResponseType& operator =(
+            const ResponseType& x);
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object ResponseType that will be copied.
+     */
+    eProsima_user_DllExport ResponseType& operator =(
+            ResponseType&& x) noexcept;
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ResponseType object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const ResponseType& x) const;
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ResponseType object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const ResponseType& x) const;
+
+    /*!
+     * @brief This function sets a value in member node_id
+     * @param _node_id New value for member node_id
+     */
+    eProsima_user_DllExport void node_id(
+            int32_t _node_id);
+
+    /*!
+     * @brief This function returns the value of member node_id
+     * @return Value of member node_id
+     */
+    eProsima_user_DllExport int32_t node_id() const;
+
+    /*!
+     * @brief This function returns a reference to member node_id
+     * @return Reference to member node_id
+     */
+    eProsima_user_DllExport int32_t& node_id();
+
+
+    /*!
+     * @brief This function sets a value in member transaction_id
+     * @param _transaction_id New value for member transaction_id
+     */
+    eProsima_user_DllExport void transaction_id(
+            int32_t _transaction_id);
+
+    /*!
+     * @brief This function returns the value of member transaction_id
+     * @return Value of member transaction_id
+     */
+    eProsima_user_DllExport int32_t transaction_id() const;
+
+    /*!
+     * @brief This function returns a reference to member transaction_id
+     * @return Reference to member transaction_id
+     */
+    eProsima_user_DllExport int32_t& transaction_id();
+
+
+    /*!
+     * @brief This function sets a value in member success
+     * @param _success New value for member success
+     */
+    eProsima_user_DllExport void success(
+            bool _success);
+
+    /*!
+     * @brief This function returns the value of member success
+     * @return Value of member success
+     */
+    eProsima_user_DllExport bool success() const;
+
+    /*!
+     * @brief This function returns a reference to member success
+     * @return Reference to member success
+     */
+    eProsima_user_DllExport bool& success();
+
+
+    /*!
+     * @brief This function sets a value in member err_code
+     * @param _err_code New value for member err_code
+     */
+    eProsima_user_DllExport void err_code(
+            ErrorCode _err_code);
+
+    /*!
+     * @brief This function returns the value of member err_code
+     * @return Value of member err_code
+     */
+    eProsima_user_DllExport ErrorCode err_code() const;
+
+    /*!
+     * @brief This function returns a reference to member err_code
+     * @return Reference to member err_code
+     */
+    eProsima_user_DllExport ErrorCode& err_code();
+
+
+    /*!
+     * @brief This function copies the value in member configuration
+     * @param _configuration New value to be copied in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            const std::string& _configuration);
+
+    /*!
+     * @brief This function moves the value in member configuration
+     * @param _configuration New value to be moved in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            std::string&& _configuration);
+
+    /*!
+     * @brief This function returns a constant reference to member configuration
+     * @return Constant reference to member configuration
+     */
+    eProsima_user_DllExport const std::string& configuration() const;
+
+    /*!
+     * @brief This function returns a reference to member configuration
+     * @return Reference to member configuration
+     */
+    eProsima_user_DllExport std::string& configuration();
+
+    /*!
+     * @brief This function returns the implementation
+     * @return Pointer to implementation
+     */
+    ResponseTypeImpl* get_impl();
+
+    /*!
+     * @brief This function retrives the implementation type info
+     * @return Reference to the typeid
+     */
+    static const std::type_info& impl_typeinfo();
+
+protected:
+
+    ResponseTypeImpl* impl_;
+    friend class ResponseTypeImpl;
 
 };
 

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -481,6 +481,14 @@ void OrchestratorNode::send_control_command(
     control_writer_->write(cmd.get_impl());
 }
 
+bool OrchestratorNode::configuration_request(
+        const types::RequestType req,
+        const types::ResponseType& res)
+{
+    //TODO: Implement this method
+    return true;
+}
+
 void OrchestratorNode::spin()
 {
     EPROSIMA_LOG_INFO(ORCHESTRATOR, "Spinning Orchestrator... ");

--- a/sustainml_cpp/src/cpp/types/types.cpp
+++ b/sustainml_cpp/src/cpp/types/types.cpp
@@ -2118,4 +2118,294 @@ const std::type_info& CO2Footprint::impl_typeinfo()
     return typeid(CO2FootprintImpl);
 }
 
+RequestType::RequestType()
+{
+    impl_ = new RequestTypeImpl;
+}
+
+RequestType::~RequestType()
+{
+    if (nullptr != impl_)
+    {
+        delete impl_;
+    }
+}
+
+RequestType::RequestType(
+        const RequestType& x)
+{
+    impl_ = new RequestTypeImpl;
+
+    this->impl_->node_id() = x.impl_->node_id();
+    this->impl_->transaction_id() = x.impl_->transaction_id();
+    this->impl_->configuration() = x.impl_->configuration();
+}
+
+RequestType::RequestType(
+        RequestType&& x) noexcept
+{
+    this->impl_ = x.impl_;
+    x.impl_ = nullptr;
+}
+
+RequestType& RequestType::operator =(
+        const RequestType& x)
+{
+    this->impl_->node_id() = x.impl_->node_id();
+    this->impl_->transaction_id() = x.impl_->transaction_id();
+    this->impl_->configuration() = x.impl_->configuration();
+    return *this;
+}
+
+RequestType& RequestType::operator =(
+        RequestType&& x) noexcept
+{
+    if (x.impl_ != this->impl_)
+    {
+        delete this->impl_;
+        this->impl_ = x.impl_;
+        x.impl_ = nullptr;
+    }
+
+    return *this;
+}
+
+bool RequestType::operator ==(
+        const RequestType& x) const
+{
+    return (this->impl_ == x.impl_);
+}
+
+bool RequestType::operator !=(
+        const RequestType& x) const
+{
+    return !(*this == x);
+}
+
+void RequestType::node_id(
+        int32_t _node_id){
+    impl_->node_id(_node_id);
+}
+
+int32_t RequestType::node_id() const
+{
+    return impl_->node_id();
+}
+
+int32_t& RequestType::node_id()
+{
+    return impl_->node_id();
+}
+
+void RequestType::transaction_id(
+        int32_t _transaction_id){
+    impl_->transaction_id(_transaction_id);
+}
+
+int32_t RequestType::transaction_id() const
+{
+    return impl_->transaction_id();
+}
+
+int32_t& RequestType::transaction_id()
+{
+    return impl_->transaction_id();
+}
+
+void RequestType::configuration(
+        const std::string& _configuration)
+{
+    impl_->configuration(_configuration);
+}
+
+void RequestType::configuration(
+        std::string&& _configuration)
+{
+    impl_->configuration(std::forward<std::string>(_configuration));
+}
+
+const std::string& RequestType::configuration() const
+{
+    return impl_->configuration();
+}
+
+std::string& RequestType::configuration()
+{
+    return impl_->configuration();
+}
+
+RequestTypeImpl* RequestType::get_impl()
+{
+    return impl_;
+}
+
+const std::type_info& RequestType::impl_typeinfo()
+{
+    return typeid(RequestTypeImpl);
+}
+
+ResponseType::ResponseType()
+{
+    impl_ = new ResponseTypeImpl;
+}
+
+ResponseType::~ResponseType()
+{
+    if (nullptr != impl_)
+    {
+        delete impl_;
+    }
+}
+
+ResponseType::ResponseType(
+        const ResponseType& x)
+{
+    impl_ = new ResponseTypeImpl;
+
+    this->impl_->node_id() = x.impl_->node_id();
+    this->impl_->transaction_id() = x.impl_->transaction_id();
+    this->impl_->success() = x.impl_->success();
+    this->impl_->err_code() = x.impl_->err_code();
+    this->impl_->configuration() = x.impl_->configuration();
+}
+
+ResponseType::ResponseType(
+    ResponseType&& x) noexcept
+{
+    this->impl_ = x.impl_;
+    x.impl_ = nullptr;
+}
+
+ResponseType& ResponseType::operator =(
+    const ResponseType& x)
+{
+    this->impl_->node_id() = x.impl_->node_id();
+    this->impl_->transaction_id() = x.impl_->transaction_id();
+    this->impl_->success() = x.impl_->success();
+    this->impl_->err_code() = x.impl_->err_code();
+    this->impl_->configuration() = x.impl_->configuration();
+    return *this;
+}
+
+ResponseType& ResponseType::operator =(
+    ResponseType&& x) noexcept
+{
+    if (x.impl_ != this->impl_)
+    {
+    delete this->impl_;
+    this->impl_ = x.impl_;
+    x.impl_ = nullptr;
+    }
+
+    return *this;
+}
+
+bool ResponseType::operator ==(
+    const ResponseType& x) const
+{
+    return (this->impl_ == x.impl_);
+}
+
+bool ResponseType::operator !=(
+    const ResponseType& x) const
+{
+    return !(*this == x);
+}
+
+void ResponseType::node_id(
+    int32_t _node_id)
+{
+    impl_->node_id(_node_id);
+}
+
+int32_t ResponseType::node_id() const
+{
+    return impl_->node_id();
+}
+
+int32_t& ResponseType::node_id()
+{
+    return impl_->node_id();
+}
+
+void ResponseType::transaction_id(
+    int32_t _transaction_id)
+{
+    impl_->transaction_id(_transaction_id);
+}
+
+int32_t ResponseType::transaction_id() const
+{
+    return impl_->transaction_id();
+}
+
+int32_t& ResponseType::transaction_id()
+{
+    return impl_->transaction_id();
+}
+
+void ResponseType::success(
+    bool _success)
+{
+    impl_->success(_success);
+}
+
+bool ResponseType::success() const
+{
+    return impl_->success();
+}
+
+bool& ResponseType::success()
+{
+    return impl_->success();
+}
+
+void ResponseType::err_code(
+    ErrorCode _err_code)
+{
+    impl_->err_code(_err_code);
+}
+
+ErrorCode ResponseType::err_code() const
+{
+    return impl_->err_code();
+}
+
+ErrorCode& ResponseType::err_code()
+{
+    return impl_->err_code();
+}
+
+void ResponseType::configuration(
+    const std::string& _configuration)
+{
+    impl_->configuration(_configuration);
+}
+
+void ResponseType::configuration(
+    std::string&& _configuration)
+{
+    impl_->configuration(std::forward<std::string>(_configuration));
+}
+
+const std::string& ResponseType::configuration() const
+{
+    return impl_->configuration();
+}
+
+std::string& ResponseType::configuration()
+{
+    return impl_->configuration();
+}
+
+ResponseTypeImpl* ResponseType::get_impl()
+{
+    return impl_;
+}
+
+const std::type_info& ResponseType::impl_typeinfo()
+{
+    return typeid(ResponseTypeImpl);
+}
+
 } // namespace types

--- a/sustainml_cpp/src/cpp/types/typesImpl.hpp
+++ b/sustainml_cpp/src/cpp/types/typesImpl.hpp
@@ -115,9 +115,9 @@ public:
     eProsima_user_DllExport TaskIdImpl(
             const TaskIdImpl& x)
     {
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
     }
 
@@ -140,9 +140,9 @@ public:
             const TaskIdImpl& x)
     {
 
-        m_problem_id = x.m_problem_id;
+                    m_problem_id = x.m_problem_id;
 
-        m_iteration_id = x.m_iteration_id;
+                    m_iteration_id = x.m_iteration_id;
 
         return *this;
     }
@@ -168,7 +168,7 @@ public:
             const TaskIdImpl& x) const
     {
         return (m_problem_id == x.m_problem_id &&
-               m_iteration_id == x.m_iteration_id);
+           m_iteration_id == x.m_iteration_id);
     }
 
     /*!
@@ -209,6 +209,7 @@ public:
         return m_problem_id;
     }
 
+
     /*!
      * @brief This function sets a value in member iteration_id
      * @param _iteration_id New value for member iteration_id
@@ -236,6 +237,8 @@ public:
     {
         return m_iteration_id;
     }
+
+
 
 private:
 
@@ -272,17 +275,17 @@ public:
     eProsima_user_DllExport NodeStatusImpl(
             const NodeStatusImpl& x)
     {
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -309,17 +312,17 @@ public:
             const NodeStatusImpl& x)
     {
 
-        m_node_status = x.m_node_status;
+                    m_node_status = x.m_node_status;
 
-        m_task_status = x.m_task_status;
+                    m_task_status = x.m_task_status;
 
-        m_error_code = x.m_error_code;
+                    m_error_code = x.m_error_code;
 
-        m_error_description = x.m_error_description;
+                    m_error_description = x.m_error_description;
 
-        m_node_name = x.m_node_name;
+                    m_node_name = x.m_node_name;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -349,11 +352,11 @@ public:
             const NodeStatusImpl& x) const
     {
         return (m_node_status == x.m_node_status &&
-               m_task_status == x.m_task_status &&
-               m_error_code == x.m_error_code &&
-               m_error_description == x.m_error_description &&
-               m_node_name == x.m_node_name &&
-               m_task_id == x.m_task_id);
+           m_task_status == x.m_task_status &&
+           m_error_code == x.m_error_code &&
+           m_error_description == x.m_error_description &&
+           m_node_name == x.m_node_name &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -394,6 +397,7 @@ public:
         return m_node_status;
     }
 
+
     /*!
      * @brief This function sets a value in member task_status
      * @param _task_status New value for member task_status
@@ -422,6 +426,7 @@ public:
         return m_task_status;
     }
 
+
     /*!
      * @brief This function sets a value in member error_code
      * @param _error_code New value for member error_code
@@ -449,6 +454,7 @@ public:
     {
         return m_error_code;
     }
+
 
     /*!
      * @brief This function copies the value in member error_description
@@ -488,6 +494,7 @@ public:
         return m_error_description;
     }
 
+
     /*!
      * @brief This function copies the value in member node_name
      * @param _node_name New value to be copied in member node_name
@@ -526,6 +533,7 @@ public:
         return m_node_name;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -563,6 +571,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -627,15 +637,15 @@ public:
     eProsima_user_DllExport NodeControlImpl(
             const NodeControlImpl& x)
     {
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -661,15 +671,15 @@ public:
             const NodeControlImpl& x)
     {
 
-        m_cmd_node = x.m_cmd_node;
+                    m_cmd_node = x.m_cmd_node;
 
-        m_cmd_task = x.m_cmd_task;
+                    m_cmd_task = x.m_cmd_task;
 
-        m_target_node = x.m_target_node;
+                    m_target_node = x.m_target_node;
 
-        m_source_node = x.m_source_node;
+                    m_source_node = x.m_source_node;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -698,10 +708,10 @@ public:
             const NodeControlImpl& x) const
     {
         return (m_cmd_node == x.m_cmd_node &&
-               m_cmd_task == x.m_cmd_task &&
-               m_target_node == x.m_target_node &&
-               m_source_node == x.m_source_node &&
-               m_task_id == x.m_task_id);
+           m_cmd_task == x.m_cmd_task &&
+           m_target_node == x.m_target_node &&
+           m_source_node == x.m_source_node &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -742,6 +752,7 @@ public:
         return m_cmd_node;
     }
 
+
     /*!
      * @brief This function sets a value in member cmd_task
      * @param _cmd_task New value for member cmd_task
@@ -769,6 +780,7 @@ public:
     {
         return m_cmd_task;
     }
+
 
     /*!
      * @brief This function copies the value in member target_node
@@ -808,6 +820,7 @@ public:
         return m_target_node;
     }
 
+
     /*!
      * @brief This function copies the value in member source_node
      * @param _source_node New value to be copied in member source_node
@@ -845,6 +858,7 @@ public:
     {
         return m_source_node;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -884,6 +898,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     CmdNode m_cmd_node{CmdNode::NO_CMD_NODE};
@@ -922,35 +938,35 @@ public:
     eProsima_user_DllExport UserInputImpl(
             const UserInputImpl& x)
     {
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -986,35 +1002,35 @@ public:
             const UserInputImpl& x)
     {
 
-        m_modality = x.m_modality;
+                    m_modality = x.m_modality;
 
-        m_problem_short_description = x.m_problem_short_description;
+                    m_problem_short_description = x.m_problem_short_description;
 
-        m_problem_definition = x.m_problem_definition;
+                    m_problem_definition = x.m_problem_definition;
 
-        m_inputs = x.m_inputs;
+                    m_inputs = x.m_inputs;
 
-        m_outputs = x.m_outputs;
+                    m_outputs = x.m_outputs;
 
-        m_minimum_samples = x.m_minimum_samples;
+                    m_minimum_samples = x.m_minimum_samples;
 
-        m_maximum_samples = x.m_maximum_samples;
+                    m_maximum_samples = x.m_maximum_samples;
 
-        m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
+                    m_optimize_carbon_footprint_manual = x.m_optimize_carbon_footprint_manual;
 
-        m_previous_iteration = x.m_previous_iteration;
+                    m_previous_iteration = x.m_previous_iteration;
 
-        m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
+                    m_optimize_carbon_footprint_auto = x.m_optimize_carbon_footprint_auto;
 
-        m_desired_carbon_footprint = x.m_desired_carbon_footprint;
+                    m_desired_carbon_footprint = x.m_desired_carbon_footprint;
 
-        m_geo_location_continent = x.m_geo_location_continent;
+                    m_geo_location_continent = x.m_geo_location_continent;
 
-        m_geo_location_region = x.m_geo_location_region;
+                    m_geo_location_region = x.m_geo_location_region;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1053,20 +1069,20 @@ public:
             const UserInputImpl& x) const
     {
         return (m_modality == x.m_modality &&
-               m_problem_short_description == x.m_problem_short_description &&
-               m_problem_definition == x.m_problem_definition &&
-               m_inputs == x.m_inputs &&
-               m_outputs == x.m_outputs &&
-               m_minimum_samples == x.m_minimum_samples &&
-               m_maximum_samples == x.m_maximum_samples &&
-               m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
-               m_previous_iteration == x.m_previous_iteration &&
-               m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
-               m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
-               m_geo_location_continent == x.m_geo_location_continent &&
-               m_geo_location_region == x.m_geo_location_region &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_problem_short_description == x.m_problem_short_description &&
+           m_problem_definition == x.m_problem_definition &&
+           m_inputs == x.m_inputs &&
+           m_outputs == x.m_outputs &&
+           m_minimum_samples == x.m_minimum_samples &&
+           m_maximum_samples == x.m_maximum_samples &&
+           m_optimize_carbon_footprint_manual == x.m_optimize_carbon_footprint_manual &&
+           m_previous_iteration == x.m_previous_iteration &&
+           m_optimize_carbon_footprint_auto == x.m_optimize_carbon_footprint_auto &&
+           m_desired_carbon_footprint == x.m_desired_carbon_footprint &&
+           m_geo_location_continent == x.m_geo_location_continent &&
+           m_geo_location_region == x.m_geo_location_region &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1117,6 +1133,7 @@ public:
         return m_modality;
     }
 
+
     /*!
      * @brief This function copies the value in member problem_short_description
      * @param _problem_short_description New value to be copied in member problem_short_description
@@ -1154,6 +1171,7 @@ public:
     {
         return m_problem_short_description;
     }
+
 
     /*!
      * @brief This function copies the value in member problem_definition
@@ -1193,6 +1211,7 @@ public:
         return m_problem_definition;
     }
 
+
     /*!
      * @brief This function copies the value in member inputs
      * @param _inputs New value to be copied in member inputs
@@ -1230,6 +1249,7 @@ public:
     {
         return m_inputs;
     }
+
 
     /*!
      * @brief This function copies the value in member outputs
@@ -1269,6 +1289,7 @@ public:
         return m_outputs;
     }
 
+
     /*!
      * @brief This function sets a value in member minimum_samples
      * @param _minimum_samples New value for member minimum_samples
@@ -1296,6 +1317,7 @@ public:
     {
         return m_minimum_samples;
     }
+
 
     /*!
      * @brief This function sets a value in member maximum_samples
@@ -1325,6 +1347,7 @@ public:
         return m_maximum_samples;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_manual
      * @param _optimize_carbon_footprint_manual New value for member optimize_carbon_footprint_manual
@@ -1352,6 +1375,7 @@ public:
     {
         return m_optimize_carbon_footprint_manual;
     }
+
 
     /*!
      * @brief This function sets a value in member previous_iteration
@@ -1381,6 +1405,7 @@ public:
         return m_previous_iteration;
     }
 
+
     /*!
      * @brief This function sets a value in member optimize_carbon_footprint_auto
      * @param _optimize_carbon_footprint_auto New value for member optimize_carbon_footprint_auto
@@ -1409,6 +1434,7 @@ public:
         return m_optimize_carbon_footprint_auto;
     }
 
+
     /*!
      * @brief This function sets a value in member desired_carbon_footprint
      * @param _desired_carbon_footprint New value for member desired_carbon_footprint
@@ -1436,6 +1462,7 @@ public:
     {
         return m_desired_carbon_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member geo_location_continent
@@ -1475,6 +1502,7 @@ public:
         return m_geo_location_continent;
     }
 
+
     /*!
      * @brief This function copies the value in member geo_location_region
      * @param _geo_location_region New value to be copied in member geo_location_region
@@ -1512,6 +1540,7 @@ public:
     {
         return m_geo_location_region;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1551,6 +1580,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1588,6 +1618,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -1637,13 +1669,13 @@ public:
     eProsima_user_DllExport MLModelMetadataImpl(
             const MLModelMetadataImpl& x)
     {
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1668,13 +1700,13 @@ public:
             const MLModelMetadataImpl& x)
     {
 
-        m_keywords = x.m_keywords;
+                    m_keywords = x.m_keywords;
 
-        m_ml_model_metadata = x.m_ml_model_metadata;
+                    m_ml_model_metadata = x.m_ml_model_metadata;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1702,9 +1734,9 @@ public:
             const MLModelMetadataImpl& x) const
     {
         return (m_keywords == x.m_keywords &&
-               m_ml_model_metadata == x.m_ml_model_metadata &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_ml_model_metadata == x.m_ml_model_metadata &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -1755,6 +1787,7 @@ public:
         return m_keywords;
     }
 
+
     /*!
      * @brief This function copies the value in member ml_model_metadata
      * @param _ml_model_metadata New value to be copied in member ml_model_metadata
@@ -1792,6 +1825,7 @@ public:
     {
         return m_ml_model_metadata;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -1831,6 +1865,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -1869,6 +1904,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_keywords;
@@ -1906,11 +1943,11 @@ public:
     eProsima_user_DllExport AppRequirementsImpl(
             const AppRequirementsImpl& x)
     {
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -1934,11 +1971,11 @@ public:
             const AppRequirementsImpl& x)
     {
 
-        m_app_requirements = x.m_app_requirements;
+                    m_app_requirements = x.m_app_requirements;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -1965,8 +2002,8 @@ public:
             const AppRequirementsImpl& x) const
     {
         return (m_app_requirements == x.m_app_requirements &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2017,6 +2054,7 @@ public:
         return m_app_requirements;
     }
 
+
     /*!
      * @brief This function copies the value in member extra_data
      * @param _extra_data New value to be copied in member extra_data
@@ -2054,6 +2092,7 @@ public:
     {
         return m_extra_data;
     }
+
 
     /*!
      * @brief This function copies the value in member task_id
@@ -2093,6 +2132,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     std::vector<std::string> m_app_requirements;
@@ -2129,13 +2170,13 @@ public:
     eProsima_user_DllExport HWConstraintsImpl(
             const HWConstraintsImpl& x)
     {
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_hardware_required = x.m_hardware_required;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2160,13 +2201,13 @@ public:
             const HWConstraintsImpl& x)
     {
 
-        m_max_memory_footprint = x.m_max_memory_footprint;
+                    m_max_memory_footprint = x.m_max_memory_footprint;
 
-        m_hardware_required = x.m_hardware_required;
+                    m_hardware_required = x.m_hardware_required;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2194,9 +2235,9 @@ public:
             const HWConstraintsImpl& x) const
     {
         return (m_max_memory_footprint == x.m_max_memory_footprint &&
-               m_hardware_required == x.m_hardware_required &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_hardware_required == x.m_hardware_required &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2237,6 +2278,7 @@ public:
         return m_max_memory_footprint;
     }
 
+
     /*!
      * @brief This function copies the value in member hardware_required
      * @param _hardware_required New value to be copied in member hardware_required
@@ -2274,6 +2316,7 @@ public:
     {
         return m_hardware_required;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2313,6 +2356,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2351,6 +2395,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     uint32_t m_max_memory_footprint{0};
@@ -2388,23 +2434,23 @@ public:
     eProsima_user_DllExport MLModelImpl(
             const MLModelImpl& x)
     {
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2434,23 +2480,23 @@ public:
             const MLModelImpl& x)
     {
 
-        m_model_path = x.m_model_path;
+                    m_model_path = x.m_model_path;
 
-        m_model = x.m_model;
+                    m_model = x.m_model;
 
-        m_raw_model = x.m_raw_model;
+                    m_raw_model = x.m_raw_model;
 
-        m_model_properties_path = x.m_model_properties_path;
+                    m_model_properties_path = x.m_model_properties_path;
 
-        m_model_properties = x.m_model_properties;
+                    m_model_properties = x.m_model_properties;
 
-        m_input_batch = x.m_input_batch;
+                    m_input_batch = x.m_input_batch;
 
-        m_target_latency = x.m_target_latency;
+                    m_target_latency = x.m_target_latency;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2483,14 +2529,14 @@ public:
             const MLModelImpl& x) const
     {
         return (m_model_path == x.m_model_path &&
-               m_model == x.m_model &&
-               m_raw_model == x.m_raw_model &&
-               m_model_properties_path == x.m_model_properties_path &&
-               m_model_properties == x.m_model_properties &&
-               m_input_batch == x.m_input_batch &&
-               m_target_latency == x.m_target_latency &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_model == x.m_model &&
+           m_raw_model == x.m_raw_model &&
+           m_model_properties_path == x.m_model_properties_path &&
+           m_model_properties == x.m_model_properties &&
+           m_input_batch == x.m_input_batch &&
+           m_target_latency == x.m_target_latency &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -2541,6 +2587,7 @@ public:
         return m_model_path;
     }
 
+
     /*!
      * @brief This function copies the value in member model
      * @param _model New value to be copied in member model
@@ -2578,6 +2625,7 @@ public:
     {
         return m_model;
     }
+
 
     /*!
      * @brief This function copies the value in member raw_model
@@ -2617,6 +2665,7 @@ public:
         return m_raw_model;
     }
 
+
     /*!
      * @brief This function copies the value in member model_properties_path
      * @param _model_properties_path New value to be copied in member model_properties_path
@@ -2654,6 +2703,7 @@ public:
     {
         return m_model_properties_path;
     }
+
 
     /*!
      * @brief This function copies the value in member model_properties
@@ -2693,6 +2743,7 @@ public:
         return m_model_properties;
     }
 
+
     /*!
      * @brief This function copies the value in member input_batch
      * @param _input_batch New value to be copied in member input_batch
@@ -2731,6 +2782,7 @@ public:
         return m_input_batch;
     }
 
+
     /*!
      * @brief This function sets a value in member target_latency
      * @param _target_latency New value for member target_latency
@@ -2758,6 +2810,7 @@ public:
     {
         return m_target_latency;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -2797,6 +2850,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -2834,6 +2888,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -2877,19 +2933,19 @@ public:
     eProsima_user_DllExport HWResourceImpl(
             const HWResourceImpl& x)
     {
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -2917,19 +2973,19 @@ public:
             const HWResourceImpl& x)
     {
 
-        m_hw_description = x.m_hw_description;
+                    m_hw_description = x.m_hw_description;
 
-        m_power_consumption = x.m_power_consumption;
+                    m_power_consumption = x.m_power_consumption;
 
-        m_latency = x.m_latency;
+                    m_latency = x.m_latency;
 
-        m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
+                    m_memory_footprint_of_ml_model = x.m_memory_footprint_of_ml_model;
 
-        m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
+                    m_max_hw_memory_footprint = x.m_max_hw_memory_footprint;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -2960,12 +3016,12 @@ public:
             const HWResourceImpl& x) const
     {
         return (m_hw_description == x.m_hw_description &&
-               m_power_consumption == x.m_power_consumption &&
-               m_latency == x.m_latency &&
-               m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
-               m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_power_consumption == x.m_power_consumption &&
+           m_latency == x.m_latency &&
+           m_memory_footprint_of_ml_model == x.m_memory_footprint_of_ml_model &&
+           m_max_hw_memory_footprint == x.m_max_hw_memory_footprint &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3016,6 +3072,7 @@ public:
         return m_hw_description;
     }
 
+
     /*!
      * @brief This function sets a value in member power_consumption
      * @param _power_consumption New value for member power_consumption
@@ -3043,6 +3100,7 @@ public:
     {
         return m_power_consumption;
     }
+
 
     /*!
      * @brief This function sets a value in member latency
@@ -3072,6 +3130,7 @@ public:
         return m_latency;
     }
 
+
     /*!
      * @brief This function sets a value in member memory_footprint_of_ml_model
      * @param _memory_footprint_of_ml_model New value for member memory_footprint_of_ml_model
@@ -3100,6 +3159,7 @@ public:
         return m_memory_footprint_of_ml_model;
     }
 
+
     /*!
      * @brief This function sets a value in member max_hw_memory_footprint
      * @param _max_hw_memory_footprint New value for member max_hw_memory_footprint
@@ -3127,6 +3187,7 @@ public:
     {
         return m_max_hw_memory_footprint;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3166,6 +3227,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3203,6 +3265,8 @@ public:
     {
         return m_task_id;
     }
+
+
 
 private:
 
@@ -3244,15 +3308,15 @@ public:
     eProsima_user_DllExport CO2FootprintImpl(
             const CO2FootprintImpl& x)
     {
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
     }
 
@@ -3278,15 +3342,15 @@ public:
             const CO2FootprintImpl& x)
     {
 
-        m_carbon_footprint = x.m_carbon_footprint;
+                    m_carbon_footprint = x.m_carbon_footprint;
 
-        m_energy_consumption = x.m_energy_consumption;
+                    m_energy_consumption = x.m_energy_consumption;
 
-        m_carbon_intensity = x.m_carbon_intensity;
+                    m_carbon_intensity = x.m_carbon_intensity;
 
-        m_extra_data = x.m_extra_data;
+                    m_extra_data = x.m_extra_data;
 
-        m_task_id = x.m_task_id;
+                    m_task_id = x.m_task_id;
 
         return *this;
     }
@@ -3315,10 +3379,10 @@ public:
             const CO2FootprintImpl& x) const
     {
         return (m_carbon_footprint == x.m_carbon_footprint &&
-               m_energy_consumption == x.m_energy_consumption &&
-               m_carbon_intensity == x.m_carbon_intensity &&
-               m_extra_data == x.m_extra_data &&
-               m_task_id == x.m_task_id);
+           m_energy_consumption == x.m_energy_consumption &&
+           m_carbon_intensity == x.m_carbon_intensity &&
+           m_extra_data == x.m_extra_data &&
+           m_task_id == x.m_task_id);
     }
 
     /*!
@@ -3359,6 +3423,7 @@ public:
         return m_carbon_footprint;
     }
 
+
     /*!
      * @brief This function sets a value in member energy_consumption
      * @param _energy_consumption New value for member energy_consumption
@@ -3387,6 +3452,7 @@ public:
         return m_energy_consumption;
     }
 
+
     /*!
      * @brief This function sets a value in member carbon_intensity
      * @param _carbon_intensity New value for member carbon_intensity
@@ -3414,6 +3480,7 @@ public:
     {
         return m_carbon_intensity;
     }
+
 
     /*!
      * @brief This function copies the value in member extra_data
@@ -3453,6 +3520,7 @@ public:
         return m_extra_data;
     }
 
+
     /*!
      * @brief This function copies the value in member task_id
      * @param _task_id New value to be copied in member task_id
@@ -3491,6 +3559,8 @@ public:
         return m_task_id;
     }
 
+
+
 private:
 
     double m_carbon_footprint{0.0};
@@ -3498,6 +3568,494 @@ private:
     double m_carbon_intensity{0.0};
     std::vector<uint8_t> m_extra_data;
     TaskIdImpl m_task_id;
+
+};
+/*!
+ * @brief This class represents the structure RequestTypeImpl defined by the user in the IDL file.
+ * @ingroup typesImpl
+ */
+class RequestTypeImpl
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport RequestTypeImpl()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~RequestTypeImpl()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object RequestTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport RequestTypeImpl(
+            const RequestTypeImpl& x)
+    {
+                    m_node_id = x.m_node_id;
+
+                    m_transaction_id = x.m_transaction_id;
+
+                    m_configuration = x.m_configuration;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object RequestTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport RequestTypeImpl(
+            RequestTypeImpl&& x) noexcept
+    {
+        m_node_id = x.m_node_id;
+        m_transaction_id = x.m_transaction_id;
+        m_configuration = std::move(x.m_configuration);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object RequestTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport RequestTypeImpl& operator =(
+            const RequestTypeImpl& x)
+    {
+
+                    m_node_id = x.m_node_id;
+
+                    m_transaction_id = x.m_transaction_id;
+
+                    m_configuration = x.m_configuration;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object RequestTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport RequestTypeImpl& operator =(
+            RequestTypeImpl&& x) noexcept
+    {
+
+        m_node_id = x.m_node_id;
+        m_transaction_id = x.m_transaction_id;
+        m_configuration = std::move(x.m_configuration);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x RequestTypeImpl object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const RequestTypeImpl& x) const
+    {
+        return (m_node_id == x.m_node_id &&
+           m_transaction_id == x.m_transaction_id &&
+           m_configuration == x.m_configuration);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x RequestTypeImpl object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const RequestTypeImpl& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function sets a value in member node_id
+     * @param _node_id New value for member node_id
+     */
+    eProsima_user_DllExport void node_id(
+            int32_t _node_id)
+    {
+        m_node_id = _node_id;
+    }
+
+    /*!
+     * @brief This function returns the value of member node_id
+     * @return Value of member node_id
+     */
+    eProsima_user_DllExport int32_t node_id() const
+    {
+        return m_node_id;
+    }
+
+    /*!
+     * @brief This function returns a reference to member node_id
+     * @return Reference to member node_id
+     */
+    eProsima_user_DllExport int32_t& node_id()
+    {
+        return m_node_id;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member transaction_id
+     * @param _transaction_id New value for member transaction_id
+     */
+    eProsima_user_DllExport void transaction_id(
+            int32_t _transaction_id)
+    {
+        m_transaction_id = _transaction_id;
+    }
+
+    /*!
+     * @brief This function returns the value of member transaction_id
+     * @return Value of member transaction_id
+     */
+    eProsima_user_DllExport int32_t transaction_id() const
+    {
+        return m_transaction_id;
+    }
+
+    /*!
+     * @brief This function returns a reference to member transaction_id
+     * @return Reference to member transaction_id
+     */
+    eProsima_user_DllExport int32_t& transaction_id()
+    {
+        return m_transaction_id;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member configuration
+     * @param _configuration New value to be copied in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            const std::string& _configuration)
+    {
+        m_configuration = _configuration;
+    }
+
+    /*!
+     * @brief This function moves the value in member configuration
+     * @param _configuration New value to be moved in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            std::string&& _configuration)
+    {
+        m_configuration = std::move(_configuration);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member configuration
+     * @return Constant reference to member configuration
+     */
+    eProsima_user_DllExport const std::string& configuration() const
+    {
+        return m_configuration;
+    }
+
+    /*!
+     * @brief This function returns a reference to member configuration
+     * @return Reference to member configuration
+     */
+    eProsima_user_DllExport std::string& configuration()
+    {
+        return m_configuration;
+    }
+
+
+
+private:
+
+    int32_t m_node_id{0};
+    int32_t m_transaction_id{0};
+    std::string m_configuration;
+
+};
+/*!
+ * @brief This class represents the structure ResponseTypeImpl defined by the user in the IDL file.
+ * @ingroup typesImpl
+ */
+class ResponseTypeImpl
+{
+public:
+
+    /*!
+     * @brief Default constructor.
+     */
+    eProsima_user_DllExport ResponseTypeImpl()
+    {
+    }
+
+    /*!
+     * @brief Default destructor.
+     */
+    eProsima_user_DllExport ~ResponseTypeImpl()
+    {
+    }
+
+    /*!
+     * @brief Copy constructor.
+     * @param x Reference to the object ResponseTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport ResponseTypeImpl(
+            const ResponseTypeImpl& x)
+    {
+                    m_node_id = x.m_node_id;
+
+                    m_transaction_id = x.m_transaction_id;
+
+                    m_success = x.m_success;
+
+                    m_err_code = x.m_err_code;
+
+                    m_configuration = x.m_configuration;
+
+    }
+
+    /*!
+     * @brief Move constructor.
+     * @param x Reference to the object ResponseTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport ResponseTypeImpl(
+            ResponseTypeImpl&& x) noexcept
+    {
+        m_node_id = x.m_node_id;
+        m_transaction_id = x.m_transaction_id;
+        m_success = x.m_success;
+        m_err_code = x.m_err_code;
+        m_configuration = std::move(x.m_configuration);
+    }
+
+    /*!
+     * @brief Copy assignment.
+     * @param x Reference to the object ResponseTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport ResponseTypeImpl& operator =(
+            const ResponseTypeImpl& x)
+    {
+
+                    m_node_id = x.m_node_id;
+
+                    m_transaction_id = x.m_transaction_id;
+
+                    m_success = x.m_success;
+
+                    m_err_code = x.m_err_code;
+
+                    m_configuration = x.m_configuration;
+
+        return *this;
+    }
+
+    /*!
+     * @brief Move assignment.
+     * @param x Reference to the object ResponseTypeImpl that will be copied.
+     */
+    eProsima_user_DllExport ResponseTypeImpl& operator =(
+            ResponseTypeImpl&& x) noexcept
+    {
+
+        m_node_id = x.m_node_id;
+        m_transaction_id = x.m_transaction_id;
+        m_success = x.m_success;
+        m_err_code = x.m_err_code;
+        m_configuration = std::move(x.m_configuration);
+        return *this;
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ResponseTypeImpl object to compare.
+     */
+    eProsima_user_DllExport bool operator ==(
+            const ResponseTypeImpl& x) const
+    {
+        return (m_node_id == x.m_node_id &&
+           m_transaction_id == x.m_transaction_id &&
+           m_success == x.m_success &&
+           m_err_code == x.m_err_code &&
+           m_configuration == x.m_configuration);
+    }
+
+    /*!
+     * @brief Comparison operator.
+     * @param x ResponseTypeImpl object to compare.
+     */
+    eProsima_user_DllExport bool operator !=(
+            const ResponseTypeImpl& x) const
+    {
+        return !(*this == x);
+    }
+
+    /*!
+     * @brief This function sets a value in member node_id
+     * @param _node_id New value for member node_id
+     */
+    eProsima_user_DllExport void node_id(
+            int32_t _node_id)
+    {
+        m_node_id = _node_id;
+    }
+
+    /*!
+     * @brief This function returns the value of member node_id
+     * @return Value of member node_id
+     */
+    eProsima_user_DllExport int32_t node_id() const
+    {
+        return m_node_id;
+    }
+
+    /*!
+     * @brief This function returns a reference to member node_id
+     * @return Reference to member node_id
+     */
+    eProsima_user_DllExport int32_t& node_id()
+    {
+        return m_node_id;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member transaction_id
+     * @param _transaction_id New value for member transaction_id
+     */
+    eProsima_user_DllExport void transaction_id(
+            int32_t _transaction_id)
+    {
+        m_transaction_id = _transaction_id;
+    }
+
+    /*!
+     * @brief This function returns the value of member transaction_id
+     * @return Value of member transaction_id
+     */
+    eProsima_user_DllExport int32_t transaction_id() const
+    {
+        return m_transaction_id;
+    }
+
+    /*!
+     * @brief This function returns a reference to member transaction_id
+     * @return Reference to member transaction_id
+     */
+    eProsima_user_DllExport int32_t& transaction_id()
+    {
+        return m_transaction_id;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member success
+     * @param _success New value for member success
+     */
+    eProsima_user_DllExport void success(
+            bool _success)
+    {
+        m_success = _success;
+    }
+
+    /*!
+     * @brief This function returns the value of member success
+     * @return Value of member success
+     */
+    eProsima_user_DllExport bool success() const
+    {
+        return m_success;
+    }
+
+    /*!
+     * @brief This function returns a reference to member success
+     * @return Reference to member success
+     */
+    eProsima_user_DllExport bool& success()
+    {
+        return m_success;
+    }
+
+
+    /*!
+     * @brief This function sets a value in member err_code
+     * @param _err_code New value for member err_code
+     */
+    eProsima_user_DllExport void err_code(
+            ErrorCode _err_code)
+    {
+        m_err_code = _err_code;
+    }
+
+    /*!
+     * @brief This function returns the value of member err_code
+     * @return Value of member err_code
+     */
+    eProsima_user_DllExport ErrorCode err_code() const
+    {
+        return m_err_code;
+    }
+
+    /*!
+     * @brief This function returns a reference to member err_code
+     * @return Reference to member err_code
+     */
+    eProsima_user_DllExport ErrorCode& err_code()
+    {
+        return m_err_code;
+    }
+
+
+    /*!
+     * @brief This function copies the value in member configuration
+     * @param _configuration New value to be copied in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            const std::string& _configuration)
+    {
+        m_configuration = _configuration;
+    }
+
+    /*!
+     * @brief This function moves the value in member configuration
+     * @param _configuration New value to be moved in member configuration
+     */
+    eProsima_user_DllExport void configuration(
+            std::string&& _configuration)
+    {
+        m_configuration = std::move(_configuration);
+    }
+
+    /*!
+     * @brief This function returns a constant reference to member configuration
+     * @return Constant reference to member configuration
+     */
+    eProsima_user_DllExport const std::string& configuration() const
+    {
+        return m_configuration;
+    }
+
+    /*!
+     * @brief This function returns a reference to member configuration
+     * @return Reference to member configuration
+     */
+    eProsima_user_DllExport std::string& configuration()
+    {
+        return m_configuration;
+    }
+
+
+
+private:
+
+    int32_t m_node_id{0};
+    int32_t m_transaction_id{0};
+    bool m_success{false};
+    ErrorCode m_err_code{ErrorCode::NO_ERROR};
+    std::string m_configuration;
 
 };
 

--- a/sustainml_cpp/src/cpp/types/typesImplCdrAux.hpp
+++ b/sustainml_cpp/src/cpp/types/typesImplCdrAux.hpp
@@ -33,6 +33,9 @@ constexpr uint32_t AppRequirementsImpl_max_key_cdr_typesize {12UL};
 constexpr uint32_t MLModelImpl_max_cdr_typesize {1080UL};
 constexpr uint32_t MLModelImpl_max_key_cdr_typesize {12UL};
 
+constexpr uint32_t RequestTypeImpl_max_cdr_typesize {272UL};
+constexpr uint32_t RequestTypeImpl_max_key_cdr_typesize {8UL};
+
 constexpr uint32_t MLModelMetadataImpl_max_cdr_typesize {36UL};
 constexpr uint32_t MLModelMetadataImpl_max_key_cdr_typesize {12UL};
 
@@ -47,6 +50,9 @@ constexpr uint32_t NodeControlImpl_max_key_cdr_typesize {272UL};
 
 
 
+
+constexpr uint32_t ResponseTypeImpl_max_cdr_typesize {280UL};
+constexpr uint32_t ResponseTypeImpl_max_key_cdr_typesize {8UL};
 
 constexpr uint32_t UserInputImpl_max_cdr_typesize {1368UL};
 constexpr uint32_t UserInputImpl_max_key_cdr_typesize {12UL};
@@ -72,8 +78,6 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data);
-
-
 
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
@@ -106,6 +110,14 @@ eProsima_user_DllExport void serialize_key(
 eProsima_user_DllExport void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const RequestTypeImpl& data);
+
+eProsima_user_DllExport void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const ResponseTypeImpl& data);
 
 
 } // namespace fastcdr

--- a/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
+++ b/sustainml_cpp/src/cpp/types/typesImplCdrAux.ipp
@@ -34,29 +34,27 @@ using namespace eprosima::fastcdr::exception;
 namespace eprosima {
 namespace fastcdr {
 
-template < >
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const TaskIdImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.problem_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.problem_id(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.iteration_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.iteration_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -64,13 +62,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const TaskIdImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -79,11 +76,11 @@ eProsima_user_DllExport void serialize(
     scdr
         << eprosima::fastcdr::MemberId(0) << data.problem_id()
         << eprosima::fastcdr::MemberId(1) << data.iteration_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         TaskIdImpl& data)
@@ -91,18 +88,18 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.problem_id();
-                        break;
+                                        case 0:
+                                                dcdr >> data.problem_id();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.iteration_id();
-                        break;
+                                        case 1:
+                                                dcdr >> data.iteration_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -117,49 +114,48 @@ void serialize_key(
         const TaskIdImpl& data)
 {
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    scdr << data.problem_id();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.problem_id();
 
-    scdr << data.iteration_id();
+                        scdr << data.iteration_id();
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const NodeStatusImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.node_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.task_status(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.task_status(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.error_code(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.error_code(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.error_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.error_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.node_name(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.node_name(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -167,13 +163,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -186,11 +181,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(3) << data.error_description()
         << eprosima::fastcdr::MemberId(4) << data.node_name()
         << eprosima::fastcdr::MemberId(5) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         NodeStatusImpl& data)
@@ -198,34 +193,34 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.node_status();
-                        break;
+                                        case 0:
+                                                dcdr >> data.node_status();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.task_status();
-                        break;
+                                        case 1:
+                                                dcdr >> data.task_status();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.error_code();
-                        break;
+                                        case 2:
+                                                dcdr >> data.error_code();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.error_description();
-                        break;
+                                        case 3:
+                                                dcdr >> data.error_description();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.node_name();
-                        break;
+                                        case 4:
+                                                dcdr >> data.node_name();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 5:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -239,51 +234,50 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeStatusImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    scdr << data.node_name();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.node_name();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const NodeControlImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.cmd_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.cmd_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.cmd_task(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.cmd_task(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.target_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.target_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.source_node(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.source_node(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -291,13 +285,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -309,11 +302,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.target_node()
         << eprosima::fastcdr::MemberId(3) << data.source_node()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         NodeControlImpl& data)
@@ -321,30 +314,30 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.cmd_node();
-                        break;
+                                        case 0:
+                                                dcdr >> data.cmd_node();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.cmd_task();
-                        break;
+                                        case 1:
+                                                dcdr >> data.cmd_task();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.target_node();
-                        break;
+                                        case 2:
+                                                dcdr >> data.target_node();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.source_node();
-                        break;
+                                        case 3:
+                                                dcdr >> data.source_node();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -358,81 +351,80 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const NodeControlImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    scdr << data.source_node();
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.source_node();
 
-    serialize_key(scdr, data.task_id());
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const UserInputImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.modality(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.modality(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.problem_short_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.problem_short_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.problem_definition(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.problem_definition(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.inputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.inputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.outputs(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.outputs(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.minimum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.minimum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.maximum_samples(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.maximum_samples(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.optimize_carbon_footprint_manual(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.optimize_carbon_footprint_manual(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.previous_iteration(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.previous_iteration(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
-                    data.optimize_carbon_footprint_auto(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(9),
+                data.optimize_carbon_footprint_auto(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
-                    data.desired_carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(10),
+                data.desired_carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
-                    data.geo_location_continent(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(11),
+                data.geo_location_continent(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
-                    data.geo_location_region(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(12),
+                data.geo_location_region(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(13),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(14),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -440,13 +432,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const UserInputImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -468,11 +459,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(12) << data.geo_location_region()
         << eprosima::fastcdr::MemberId(13) << data.extra_data()
         << eprosima::fastcdr::MemberId(14) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         UserInputImpl& data)
@@ -480,70 +471,70 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.modality();
-                        break;
+                                        case 0:
+                                                dcdr >> data.modality();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.problem_short_description();
-                        break;
+                                        case 1:
+                                                dcdr >> data.problem_short_description();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.problem_definition();
-                        break;
+                                        case 2:
+                                                dcdr >> data.problem_definition();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.inputs();
-                        break;
+                                        case 3:
+                                                dcdr >> data.inputs();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.outputs();
-                        break;
+                                        case 4:
+                                                dcdr >> data.outputs();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.minimum_samples();
-                        break;
+                                        case 5:
+                                                dcdr >> data.minimum_samples();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.maximum_samples();
-                        break;
+                                        case 6:
+                                                dcdr >> data.maximum_samples();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.optimize_carbon_footprint_manual();
-                        break;
+                                        case 7:
+                                                dcdr >> data.optimize_carbon_footprint_manual();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.previous_iteration();
-                        break;
+                                        case 8:
+                                                dcdr >> data.previous_iteration();
+                                            break;
 
-                    case 9:
-                        dcdr >> data.optimize_carbon_footprint_auto();
-                        break;
+                                        case 9:
+                                                dcdr >> data.optimize_carbon_footprint_auto();
+                                            break;
 
-                    case 10:
-                        dcdr >> data.desired_carbon_footprint();
-                        break;
+                                        case 10:
+                                                dcdr >> data.desired_carbon_footprint();
+                                            break;
 
-                    case 11:
-                        dcdr >> data.geo_location_continent();
-                        break;
+                                        case 11:
+                                                dcdr >> data.geo_location_continent();
+                                            break;
 
-                    case 12:
-                        dcdr >> data.geo_location_region();
-                        break;
+                                        case 12:
+                                                dcdr >> data.geo_location_region();
+                                            break;
 
-                    case 13:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 13:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 14:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 14:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -557,46 +548,45 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const UserInputImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const MLModelMetadataImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.keywords(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.keywords(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.ml_model_metadata(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.ml_model_metadata(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -604,13 +594,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelMetadataImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -621,11 +610,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.ml_model_metadata()
         << eprosima::fastcdr::MemberId(2) << data.extra_data()
         << eprosima::fastcdr::MemberId(3) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         MLModelMetadataImpl& data)
@@ -633,26 +622,26 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.keywords();
-                        break;
+                                        case 0:
+                                                dcdr >> data.keywords();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.ml_model_metadata();
-                        break;
+                                        case 1:
+                                                dcdr >> data.ml_model_metadata();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -666,43 +655,42 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelMetadataImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const AppRequirementsImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.app_requirements(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.app_requirements(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -710,13 +698,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const AppRequirementsImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -726,11 +713,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(0) << data.app_requirements()
         << eprosima::fastcdr::MemberId(1) << data.extra_data()
         << eprosima::fastcdr::MemberId(2) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         AppRequirementsImpl& data)
@@ -738,22 +725,22 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.app_requirements();
-                        break;
+                                        case 0:
+                                                dcdr >> data.app_requirements();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 1:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 2:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -767,46 +754,45 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const AppRequirementsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const HWConstraintsImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.max_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.max_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.hardware_required(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.hardware_required(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -814,13 +800,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const HWConstraintsImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -831,11 +816,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(1) << data.hardware_required()
         << eprosima::fastcdr::MemberId(2) << data.extra_data()
         << eprosima::fastcdr::MemberId(3) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         HWConstraintsImpl& data)
@@ -843,26 +828,26 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.max_memory_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.max_memory_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.hardware_required();
-                        break;
+                                        case 1:
+                                                dcdr >> data.hardware_required();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 2:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 3:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -876,61 +861,60 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWConstraintsImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const MLModelImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.model_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.model_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.raw_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.raw_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.model_properties_path(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.model_properties_path(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.model_properties(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.model_properties(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.input_batch(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.input_batch(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.target_latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.target_latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(7),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(8),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -938,13 +922,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -960,11 +943,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(6) << data.target_latency()
         << eprosima::fastcdr::MemberId(7) << data.extra_data()
         << eprosima::fastcdr::MemberId(8) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         MLModelImpl& data)
@@ -972,46 +955,46 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.model_path();
-                        break;
+                                        case 0:
+                                                dcdr >> data.model_path();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.model();
-                        break;
+                                        case 1:
+                                                dcdr >> data.model();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.raw_model();
-                        break;
+                                        case 2:
+                                                dcdr >> data.raw_model();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.model_properties_path();
-                        break;
+                                        case 3:
+                                                dcdr >> data.model_properties_path();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.model_properties();
-                        break;
+                                        case 4:
+                                                dcdr >> data.model_properties();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.input_batch();
-                        break;
+                                        case 5:
+                                                dcdr >> data.input_batch();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.target_latency();
-                        break;
+                                        case 6:
+                                                dcdr >> data.target_latency();
+                                            break;
 
-                    case 7:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 7:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 8:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 8:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1025,55 +1008,54 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const MLModelImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const HWResourceImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.hw_description(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.hw_description(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.power_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.power_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.latency(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.latency(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.memory_footprint_of_ml_model(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.memory_footprint_of_ml_model(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.max_hw_memory_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.max_hw_memory_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(5),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(6),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1081,13 +1063,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const HWResourceImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -1101,11 +1082,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(4) << data.max_hw_memory_footprint()
         << eprosima::fastcdr::MemberId(5) << data.extra_data()
         << eprosima::fastcdr::MemberId(6) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         HWResourceImpl& data)
@@ -1113,38 +1094,38 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.hw_description();
-                        break;
+                                        case 0:
+                                                dcdr >> data.hw_description();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.power_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.power_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.latency();
-                        break;
+                                        case 2:
+                                                dcdr >> data.latency();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.memory_footprint_of_ml_model();
-                        break;
+                                        case 3:
+                                                dcdr >> data.memory_footprint_of_ml_model();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.max_hw_memory_footprint();
-                        break;
+                                        case 4:
+                                                dcdr >> data.max_hw_memory_footprint();
+                                            break;
 
-                    case 5:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 5:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 6:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 6:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1158,49 +1139,48 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const HWResourceImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-template < >
+
+template<>
 eProsima_user_DllExport size_t calculate_serialized_size(
         eprosima::fastcdr::CdrSizeCalculator& calculator,
         const CO2FootprintImpl& data,
         size_t& current_alignment)
 {
-    static_cast < void > (data);
+    static_cast<void>(data);
 
     eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
-    size_t calculated_size {
-        calculator.begin_calculate_type_serialized_size(
-            eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
-            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
-            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            current_alignment)
-    };
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
 
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
-                    data.carbon_footprint(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.carbon_footprint(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
-                    data.energy_consumption(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.energy_consumption(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
-                    data.carbon_intensity(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.carbon_intensity(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
-                    data.extra_data(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.extra_data(), current_alignment);
 
-    calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
-                    data.task_id(), current_alignment);
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.task_id(), current_alignment);
 
 
     calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
@@ -1208,13 +1188,12 @@ eProsima_user_DllExport size_t calculate_serialized_size(
     return calculated_size;
 }
 
-template < >
+template<>
 eProsima_user_DllExport void serialize(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data)
 {
-    eprosima::fastcdr::Cdr::state current_state(
-        scdr);
+    eprosima::fastcdr::Cdr::state current_state(scdr);
     scdr.begin_serialize_type(current_state,
             eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
@@ -1226,11 +1205,11 @@ eProsima_user_DllExport void serialize(
         << eprosima::fastcdr::MemberId(2) << data.carbon_intensity()
         << eprosima::fastcdr::MemberId(3) << data.extra_data()
         << eprosima::fastcdr::MemberId(4) << data.task_id()
-    ;
+;
     scdr.end_serialize_type(current_state);
 }
 
-template < >
+template<>
 eProsima_user_DllExport void deserialize(
         eprosima::fastcdr::Cdr& cdr,
         CO2FootprintImpl& data)
@@ -1238,30 +1217,30 @@ eProsima_user_DllExport void deserialize(
     cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
             eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
             eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
-            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid)->bool
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
             {
                 bool ret_value = true;
                 switch (mid.id)
                 {
-                    case 0:
-                        dcdr >> data.carbon_footprint();
-                        break;
+                                        case 0:
+                                                dcdr >> data.carbon_footprint();
+                                            break;
 
-                    case 1:
-                        dcdr >> data.energy_consumption();
-                        break;
+                                        case 1:
+                                                dcdr >> data.energy_consumption();
+                                            break;
 
-                    case 2:
-                        dcdr >> data.carbon_intensity();
-                        break;
+                                        case 2:
+                                                dcdr >> data.carbon_intensity();
+                                            break;
 
-                    case 3:
-                        dcdr >> data.extra_data();
-                        break;
+                                        case 3:
+                                                dcdr >> data.extra_data();
+                                            break;
 
-                    case 4:
-                        dcdr >> data.task_id();
-                        break;
+                                        case 4:
+                                                dcdr >> data.task_id();
+                                            break;
 
                     default:
                         ret_value = false;
@@ -1275,18 +1254,234 @@ void serialize_key(
         eprosima::fastcdr::Cdr& scdr,
         const CO2FootprintImpl& data)
 {
-    extern void serialize_key(
-        Cdr & scdr,
-        const TaskIdImpl& data);
+            extern void serialize_key(
+                    Cdr& scdr,
+                    const TaskIdImpl& data);
 
 
-    static_cast < void > (scdr);
-    static_cast < void > (data);
-    serialize_key(scdr, data.task_id());
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        serialize_key(scdr, data.task_id());
 
 }
 
-}     // namespace fastcdr
+
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const RequestTypeImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_id(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.transaction_id(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.configuration(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const RequestTypeImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.node_id()
+        << eprosima::fastcdr::MemberId(1) << data.transaction_id()
+        << eprosima::fastcdr::MemberId(2) << data.configuration()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        RequestTypeImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0:
+                                                dcdr >> data.node_id();
+                                            break;
+
+                                        case 1:
+                                                dcdr >> data.transaction_id();
+                                            break;
+
+                                        case 2:
+                                                dcdr >> data.configuration();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const RequestTypeImpl& data)
+{
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.node_id();
+
+                        scdr << data.transaction_id();
+
+
+}
+
+
+template<>
+eProsima_user_DllExport size_t calculate_serialized_size(
+        eprosima::fastcdr::CdrSizeCalculator& calculator,
+        const ResponseTypeImpl& data,
+        size_t& current_alignment)
+{
+    static_cast<void>(data);
+
+    eprosima::fastcdr::EncodingAlgorithmFlag previous_encoding = calculator.get_encoding();
+    size_t calculated_size {calculator.begin_calculate_type_serialized_size(
+                                eprosima::fastcdr::CdrVersion::XCDRv2 == calculator.get_cdr_version() ?
+                                eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+                                eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+                                current_alignment)};
+
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(0),
+                data.node_id(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(1),
+                data.transaction_id(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(2),
+                data.success(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(3),
+                data.err_code(), current_alignment);
+
+        calculated_size += calculator.calculate_member_serialized_size(eprosima::fastcdr::MemberId(4),
+                data.configuration(), current_alignment);
+
+
+    calculated_size += calculator.end_calculate_type_serialized_size(previous_encoding, current_alignment);
+
+    return calculated_size;
+}
+
+template<>
+eProsima_user_DllExport void serialize(
+        eprosima::fastcdr::Cdr& scdr,
+        const ResponseTypeImpl& data)
+{
+    eprosima::fastcdr::Cdr::state current_state(scdr);
+    scdr.begin_serialize_type(current_state,
+            eprosima::fastcdr::CdrVersion::XCDRv2 == scdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR);
+
+    scdr
+        << eprosima::fastcdr::MemberId(0) << data.node_id()
+        << eprosima::fastcdr::MemberId(1) << data.transaction_id()
+        << eprosima::fastcdr::MemberId(2) << data.success()
+        << eprosima::fastcdr::MemberId(3) << data.err_code()
+        << eprosima::fastcdr::MemberId(4) << data.configuration()
+;
+    scdr.end_serialize_type(current_state);
+}
+
+template<>
+eProsima_user_DllExport void deserialize(
+        eprosima::fastcdr::Cdr& cdr,
+        ResponseTypeImpl& data)
+{
+    cdr.deserialize_type(eprosima::fastcdr::CdrVersion::XCDRv2 == cdr.get_cdr_version() ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2 :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR,
+            [&data](eprosima::fastcdr::Cdr& dcdr, const eprosima::fastcdr::MemberId& mid) -> bool
+            {
+                bool ret_value = true;
+                switch (mid.id)
+                {
+                                        case 0:
+                                                dcdr >> data.node_id();
+                                            break;
+
+                                        case 1:
+                                                dcdr >> data.transaction_id();
+                                            break;
+
+                                        case 2:
+                                                dcdr >> data.success();
+                                            break;
+
+                                        case 3:
+                                                dcdr >> data.err_code();
+                                            break;
+
+                                        case 4:
+                                                dcdr >> data.configuration();
+                                            break;
+
+                    default:
+                        ret_value = false;
+                        break;
+                }
+                return ret_value;
+            });
+}
+
+void serialize_key(
+        eprosima::fastcdr::Cdr& scdr,
+        const ResponseTypeImpl& data)
+{
+
+    static_cast<void>(scdr);
+    static_cast<void>(data);
+                        scdr << data.node_id();
+
+                        scdr << data.transaction_id();
+
+
+
+
+}
+
+
+
+} // namespace fastcdr
 } // namespace eprosima
 
 #endif // FAST_DDS_GENERATED__TYPESIMPLCDRAUX_IPP

--- a/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.cxx
+++ b/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.cxx
@@ -76,6 +76,7 @@ bool TaskIdImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -128,8 +129,8 @@ uint32_t TaskIdImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const TaskIdImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const TaskIdImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -184,8 +185,7 @@ bool TaskIdImplPubSubType::compute_key(
             TaskIdImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || TaskIdImpl_max_key_cdr_typesize > 16)
@@ -258,6 +258,7 @@ bool NodeStatusImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -310,8 +311,8 @@ uint32_t NodeStatusImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeStatusImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -366,8 +367,7 @@ bool NodeStatusImplPubSubType::compute_key(
             NodeStatusImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeStatusImpl_max_key_cdr_typesize > 16)
@@ -440,6 +440,7 @@ bool NodeControlImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -492,8 +493,8 @@ uint32_t NodeControlImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const NodeControlImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const NodeControlImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -548,8 +549,7 @@ bool NodeControlImplPubSubType::compute_key(
             NodeControlImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || NodeControlImpl_max_key_cdr_typesize > 16)
@@ -622,6 +622,7 @@ bool UserInputImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -674,8 +675,8 @@ uint32_t UserInputImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const UserInputImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const UserInputImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -730,8 +731,7 @@ bool UserInputImplPubSubType::compute_key(
             UserInputImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || UserInputImpl_max_key_cdr_typesize > 16)
@@ -804,6 +804,7 @@ bool MLModelMetadataImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -856,8 +857,8 @@ uint32_t MLModelMetadataImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelMetadataImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -912,8 +913,7 @@ bool MLModelMetadataImplPubSubType::compute_key(
             MLModelMetadataImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelMetadataImpl_max_key_cdr_typesize > 16)
@@ -986,6 +986,7 @@ bool AppRequirementsImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1038,8 +1039,8 @@ uint32_t AppRequirementsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const AppRequirementsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1094,8 +1095,7 @@ bool AppRequirementsImplPubSubType::compute_key(
             AppRequirementsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || AppRequirementsImpl_max_key_cdr_typesize > 16)
@@ -1168,6 +1168,7 @@ bool HWConstraintsImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1220,8 +1221,8 @@ uint32_t HWConstraintsImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWConstraintsImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1276,8 +1277,7 @@ bool HWConstraintsImplPubSubType::compute_key(
             HWConstraintsImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWConstraintsImpl_max_key_cdr_typesize > 16)
@@ -1350,6 +1350,7 @@ bool MLModelImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1402,8 +1403,8 @@ uint32_t MLModelImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const MLModelImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const MLModelImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1458,8 +1459,7 @@ bool MLModelImplPubSubType::compute_key(
             MLModelImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || MLModelImpl_max_key_cdr_typesize > 16)
@@ -1532,6 +1532,7 @@ bool HWResourceImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1584,8 +1585,8 @@ uint32_t HWResourceImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const HWResourceImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const HWResourceImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1640,8 +1641,7 @@ bool HWResourceImplPubSubType::compute_key(
             HWResourceImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || HWResourceImpl_max_key_cdr_typesize > 16)
@@ -1714,6 +1714,7 @@ bool CO2FootprintImplPubSubType::serialize(
         ser.serialize_encapsulation();
         // Serialize the object.
         ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1766,8 +1767,8 @@ uint32_t CO2FootprintImplPubSubType::calculate_serialized_size(
             eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
         size_t current_alignment {0};
         return static_cast<uint32_t>(calculator.calculate_serialized_size(
-                   *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
-               4u /*encapsulation*/;
+                    *static_cast<const CO2FootprintImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
     }
     catch (eprosima::fastcdr::exception::Exception& /*exception*/)
     {
@@ -1822,8 +1823,7 @@ bool CO2FootprintImplPubSubType::compute_key(
             CO2FootprintImpl_max_key_cdr_typesize);
 
     // Object that serializes the data.
-    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS,
-            eprosima::fastcdr::CdrVersion::XCDRv2);
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
     ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
     eprosima::fastcdr::serialize_key(ser, *p_type);
     if (force_md5 || CO2FootprintImpl_max_key_cdr_typesize > 16)
@@ -1850,6 +1850,371 @@ void CO2FootprintImplPubSubType::register_type_object_representation()
 {
     register_CO2FootprintImpl_type_identifier(type_identifiers_);
 }
+
+RequestTypeImplPubSubType::RequestTypeImplPubSubType()
+{
+    set_name("RequestTypeImpl");
+    uint32_t type_size = RequestTypeImpl_max_cdr_typesize;
+    type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+    max_serialized_type_size = type_size + 4; /*encapsulation*/
+    is_compute_key_provided = true;
+    uint32_t key_length = RequestTypeImpl_max_key_cdr_typesize > 16 ? RequestTypeImpl_max_key_cdr_typesize : 16;
+    key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+    memset(key_buffer_, 0, key_length);
+}
+
+RequestTypeImplPubSubType::~RequestTypeImplPubSubType()
+{
+    if (key_buffer_ != nullptr)
+    {
+        free(key_buffer_);
+    }
+}
+
+bool RequestTypeImplPubSubType::serialize(
+        const void* const data,
+        SerializedPayload_t& payload,
+        DataRepresentationId_t data_representation)
+{
+    const RequestTypeImpl* p_type = static_cast<const RequestTypeImpl*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+    payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    ser.set_encoding_flag(
+        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+    try
+    {
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        // Serialize the object.
+        ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    // Get the serialized length
+    payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+    return true;
+}
+
+bool RequestTypeImplPubSubType::deserialize(
+        SerializedPayload_t& payload,
+        void* data)
+{
+    try
+    {
+        // Convert DATA to pointer of your type
+        RequestTypeImpl* p_type = static_cast<RequestTypeImpl*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        // Deserialize the object.
+        deser >> *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t RequestTypeImplPubSubType::calculate_serialized_size(
+        const void* const data,
+        DataRepresentationId_t data_representation)
+{
+    try
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+        size_t current_alignment {0};
+        return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                    *static_cast<const RequestTypeImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return 0;
+    }
+}
+
+void* RequestTypeImplPubSubType::create_data()
+{
+    return reinterpret_cast<void*>(new RequestTypeImpl());
+}
+
+void RequestTypeImplPubSubType::delete_data(
+        void* data)
+{
+    delete(reinterpret_cast<RequestTypeImpl*>(data));
+}
+
+bool RequestTypeImplPubSubType::compute_key(
+        SerializedPayload_t& payload,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    RequestTypeImpl data;
+    if (deserialize(payload, static_cast<void*>(&data)))
+    {
+        return compute_key(static_cast<void*>(&data), handle, force_md5);
+    }
+
+    return false;
+}
+
+bool RequestTypeImplPubSubType::compute_key(
+        const void* const data,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    const RequestTypeImpl* p_type = static_cast<const RequestTypeImpl*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+            RequestTypeImpl_max_key_cdr_typesize);
+
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+    eprosima::fastcdr::serialize_key(ser, *p_type);
+    if (force_md5 || RequestTypeImpl_max_key_cdr_typesize > 16)
+    {
+        md5_.init();
+        md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+        md5_.finalize();
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = md5_.digest[i];
+        }
+    }
+    else
+    {
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = key_buffer_[i];
+        }
+    }
+    return true;
+}
+
+void RequestTypeImplPubSubType::register_type_object_representation()
+{
+    register_RequestTypeImpl_type_identifier(type_identifiers_);
+}
+
+ResponseTypeImplPubSubType::ResponseTypeImplPubSubType()
+{
+    set_name("ResponseTypeImpl");
+    uint32_t type_size = ResponseTypeImpl_max_cdr_typesize;
+    type_size += static_cast<uint32_t>(eprosima::fastcdr::Cdr::alignment(type_size, 4)); /* possible submessage alignment */
+    max_serialized_type_size = type_size + 4; /*encapsulation*/
+    is_compute_key_provided = true;
+    uint32_t key_length = ResponseTypeImpl_max_key_cdr_typesize > 16 ? ResponseTypeImpl_max_key_cdr_typesize : 16;
+    key_buffer_ = reinterpret_cast<unsigned char*>(malloc(key_length));
+    memset(key_buffer_, 0, key_length);
+}
+
+ResponseTypeImplPubSubType::~ResponseTypeImplPubSubType()
+{
+    if (key_buffer_ != nullptr)
+    {
+        free(key_buffer_);
+    }
+}
+
+bool ResponseTypeImplPubSubType::serialize(
+        const void* const data,
+        SerializedPayload_t& payload,
+        DataRepresentationId_t data_representation)
+{
+    const ResponseTypeImpl* p_type = static_cast<const ResponseTypeImpl*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+    payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+    ser.set_encoding_flag(
+        data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+        eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR  :
+        eprosima::fastcdr::EncodingAlgorithmFlag::DELIMIT_CDR2);
+
+    try
+    {
+        // Serialize encapsulation
+        ser.serialize_encapsulation();
+        // Serialize the object.
+        ser << *p_type;
+        ser.set_dds_cdr_options({0,0});
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    // Get the serialized length
+    payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+    return true;
+}
+
+bool ResponseTypeImplPubSubType::deserialize(
+        SerializedPayload_t& payload,
+        void* data)
+{
+    try
+    {
+        // Convert DATA to pointer of your type
+        ResponseTypeImpl* p_type = static_cast<ResponseTypeImpl*>(data);
+
+        // Object that manages the raw buffer.
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+        // Object that deserializes the data.
+        eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+        // Deserialize encapsulation.
+        deser.read_encapsulation();
+        payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+        // Deserialize the object.
+        deser >> *p_type;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+uint32_t ResponseTypeImplPubSubType::calculate_serialized_size(
+        const void* const data,
+        DataRepresentationId_t data_representation)
+{
+    try
+    {
+        eprosima::fastcdr::CdrSizeCalculator calculator(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+        size_t current_alignment {0};
+        return static_cast<uint32_t>(calculator.calculate_serialized_size(
+                    *static_cast<const ResponseTypeImpl*>(data), current_alignment)) +
+                4u /*encapsulation*/;
+    }
+    catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+    {
+        return 0;
+    }
+}
+
+void* ResponseTypeImplPubSubType::create_data()
+{
+    return reinterpret_cast<void*>(new ResponseTypeImpl());
+}
+
+void ResponseTypeImplPubSubType::delete_data(
+        void* data)
+{
+    delete(reinterpret_cast<ResponseTypeImpl*>(data));
+}
+
+bool ResponseTypeImplPubSubType::compute_key(
+        SerializedPayload_t& payload,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    ResponseTypeImpl data;
+    if (deserialize(payload, static_cast<void*>(&data)))
+    {
+        return compute_key(static_cast<void*>(&data), handle, force_md5);
+    }
+
+    return false;
+}
+
+bool ResponseTypeImplPubSubType::compute_key(
+        const void* const data,
+        InstanceHandle_t& handle,
+        bool force_md5)
+{
+    if (!is_compute_key_provided)
+    {
+        return false;
+    }
+
+    const ResponseTypeImpl* p_type = static_cast<const ResponseTypeImpl*>(data);
+
+    // Object that manages the raw buffer.
+    eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(key_buffer_),
+            ResponseTypeImpl_max_key_cdr_typesize);
+
+    // Object that serializes the data.
+    eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::BIG_ENDIANNESS, eprosima::fastcdr::CdrVersion::XCDRv2);
+    ser.set_encoding_flag(eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+    eprosima::fastcdr::serialize_key(ser, *p_type);
+    if (force_md5 || ResponseTypeImpl_max_key_cdr_typesize > 16)
+    {
+        md5_.init();
+        md5_.update(key_buffer_, static_cast<unsigned int>(ser.get_serialized_data_length()));
+        md5_.finalize();
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = md5_.digest[i];
+        }
+    }
+    else
+    {
+        for (uint8_t i = 0; i < 16; ++i)
+        {
+            handle.value[i] = key_buffer_[i];
+        }
+    }
+    return true;
+}
+
+void ResponseTypeImplPubSubType::register_type_object_representation()
+{
+    register_ResponseTypeImpl_type_identifier(type_identifiers_);
+}
+
 
 // Include auxiliary functions like for serializing/deserializing.
 #include "typesImplCdrAux.ipp"

--- a/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.hpp
+++ b/sustainml_cpp/src/cpp/types/typesImplPubSubTypes.hpp
@@ -200,8 +200,6 @@ private:
 
 };
 
-
-
 /*!
  * @brief This class represents the TopicDataType of the type NodeControlImpl defined by the user in the IDL file.
  * @ingroup typesImpl
@@ -782,6 +780,168 @@ public:
     eProsima_user_DllExport CO2FootprintImplPubSubType();
 
     eProsima_user_DllExport ~CO2FootprintImplPubSubType() override;
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override;
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport void* create_data() override;
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override;
+
+    //Register TypeObject representation in Fast DDS TypeObjectRegistry
+    eProsima_user_DllExport void register_type_object_representation() override;
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+    eProsima_user_DllExport inline bool is_bounded() const override
+    {
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+    eProsima_user_DllExport inline bool is_plain(
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        static_cast<void>(data_representation);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+    eProsima_user_DllExport inline bool construct_sample(
+            void* memory) const override
+    {
+        static_cast<void>(memory);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+private:
+
+    eprosima::fastdds::MD5 md5_;
+    unsigned char* key_buffer_;
+
+};
+
+/*!
+ * @brief This class represents the TopicDataType of the type RequestTypeImpl defined by the user in the IDL file.
+ * @ingroup typesImpl
+ */
+class RequestTypeImplPubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+
+    typedef RequestTypeImpl type;
+
+    eProsima_user_DllExport RequestTypeImplPubSubType();
+
+    eProsima_user_DllExport ~RequestTypeImplPubSubType() override;
+
+    eProsima_user_DllExport bool serialize(
+            const void* const data,
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool deserialize(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            void* data) override;
+
+    eProsima_user_DllExport uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override;
+
+    eProsima_user_DllExport bool compute_key(
+            eprosima::fastdds::rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport bool compute_key(
+            const void* const data,
+            eprosima::fastdds::rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override;
+
+    eProsima_user_DllExport void* create_data() override;
+
+    eProsima_user_DllExport void delete_data(
+            void* data) override;
+
+    //Register TypeObject representation in Fast DDS TypeObjectRegistry
+    eProsima_user_DllExport void register_type_object_representation() override;
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+    eProsima_user_DllExport inline bool is_bounded() const override
+    {
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_BOUNDED
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+    eProsima_user_DllExport inline bool is_plain(
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) const override
+    {
+        static_cast<void>(data_representation);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_IS_PLAIN
+
+#ifdef TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+    eProsima_user_DllExport inline bool construct_sample(
+            void* memory) const override
+    {
+        static_cast<void>(memory);
+        return false;
+    }
+
+#endif  // TOPIC_DATA_TYPE_API_HAS_CONSTRUCT_SAMPLE
+
+private:
+
+    eprosima::fastdds::MD5 md5_;
+    unsigned char* key_buffer_;
+
+};
+
+/*!
+ * @brief This class represents the TopicDataType of the type ResponseTypeImpl defined by the user in the IDL file.
+ * @ingroup typesImpl
+ */
+class ResponseTypeImplPubSubType : public eprosima::fastdds::dds::TopicDataType
+{
+public:
+
+    typedef ResponseTypeImpl type;
+
+    eProsima_user_DllExport ResponseTypeImplPubSubType();
+
+    eProsima_user_DllExport ~ResponseTypeImplPubSubType() override;
 
     eProsima_user_DllExport bool serialize(
             const void* const data,

--- a/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.cxx
+++ b/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.cxx
@@ -43,8 +43,7 @@ void register_Status_type_identifier(
 {
     ReturnCode_t return_code_Status {eprosima::fastdds::dds::RETCODE_OK};
     return_code_Status =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "Status", type_ids_Status);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_Status)
     {
@@ -54,204 +53,151 @@ void register_Status_type_identifier(
         QualifiedTypeName type_name_Status = "Status";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_Status;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_Status;
-        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status,
-                        ann_custom_Status,
-                        type_name_Status.to_string());
-        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status,
-                        detail_Status);
+        CompleteTypeDetail detail_Status = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_Status, ann_custom_Status, type_name_Status.to_string());
+        CompleteEnumeratedHeader header_Status = TypeObjectUtils::build_complete_enumerated_header(common_Status, detail_Status);
         CompleteEnumeratedLiteralSeq literal_seq_Status;
         {
             EnumeratedLiteralFlag flags_NODE_INACTIVE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NODE_INACTIVE);
+            CommonEnumeratedLiteral common_NODE_INACTIVE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NODE_INACTIVE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INACTIVE;
             ann_custom_Status.reset();
             MemberName name_NODE_INACTIVE = "NODE_INACTIVE";
-            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INACTIVE, detail_NODE_INACTIVE);
+            CompleteMemberDetail detail_NODE_INACTIVE = TypeObjectUtils::build_complete_member_detail(name_NODE_INACTIVE, member_ann_builtin_NODE_INACTIVE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INACTIVE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INACTIVE, detail_NODE_INACTIVE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INACTIVE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_NODE_ERROR);
+            CommonEnumeratedLiteral common_NODE_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_NODE_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_ERROR;
             ann_custom_Status.reset();
             MemberName name_NODE_ERROR = "NODE_ERROR";
-            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR,
-                            member_ann_builtin_NODE_ERROR,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_ERROR, detail_NODE_ERROR);
+            CompleteMemberDetail detail_NODE_ERROR = TypeObjectUtils::build_complete_member_detail(name_NODE_ERROR, member_ann_builtin_NODE_ERROR, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_ERROR, detail_NODE_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_NODE_IDLE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_NODE_IDLE);
+            CommonEnumeratedLiteral common_NODE_IDLE = TypeObjectUtils::build_common_enumerated_literal(2, flags_NODE_IDLE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_IDLE;
             ann_custom_Status.reset();
             MemberName name_NODE_IDLE = "NODE_IDLE";
-            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE,
-                            member_ann_builtin_NODE_IDLE,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_IDLE, detail_NODE_IDLE);
+            CompleteMemberDetail detail_NODE_IDLE = TypeObjectUtils::build_complete_member_detail(name_NODE_IDLE, member_ann_builtin_NODE_IDLE, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_IDLE = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_IDLE, detail_NODE_IDLE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_IDLE);
         }
         {
             EnumeratedLiteralFlag flags_NODE_INITIALIZING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_NODE_INITIALIZING);
+            CommonEnumeratedLiteral common_NODE_INITIALIZING = TypeObjectUtils::build_common_enumerated_literal(3, flags_NODE_INITIALIZING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_INITIALIZING;
             ann_custom_Status.reset();
             MemberName name_NODE_INITIALIZING = "NODE_INITIALIZING";
-            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
+            CompleteMemberDetail detail_NODE_INITIALIZING = TypeObjectUtils::build_complete_member_detail(name_NODE_INITIALIZING, member_ann_builtin_NODE_INITIALIZING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_INITIALIZING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_INITIALIZING, detail_NODE_INITIALIZING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_INITIALIZING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_NODE_RUNNING);
+            CommonEnumeratedLiteral common_NODE_RUNNING = TypeObjectUtils::build_common_enumerated_literal(4, flags_NODE_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_RUNNING;
             ann_custom_Status.reset();
             MemberName name_NODE_RUNNING = "NODE_RUNNING";
-            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING,
-                            member_ann_builtin_NODE_RUNNING,
-                            ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_RUNNING, detail_NODE_RUNNING);
+            CompleteMemberDetail detail_NODE_RUNNING = TypeObjectUtils::build_complete_member_detail(name_NODE_RUNNING, member_ann_builtin_NODE_RUNNING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_RUNNING, detail_NODE_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_NODE_TERMINATING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5,
-                            flags_NODE_TERMINATING);
+            CommonEnumeratedLiteral common_NODE_TERMINATING = TypeObjectUtils::build_common_enumerated_literal(5, flags_NODE_TERMINATING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NODE_TERMINATING;
             ann_custom_Status.reset();
             MemberName name_NODE_TERMINATING = "NODE_TERMINATING";
-            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(
-                name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
-            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NODE_TERMINATING, detail_NODE_TERMINATING);
+            CompleteMemberDetail detail_NODE_TERMINATING = TypeObjectUtils::build_complete_member_detail(name_NODE_TERMINATING, member_ann_builtin_NODE_TERMINATING, ann_custom_Status);
+            CompleteEnumeratedLiteral literal_NODE_TERMINATING = TypeObjectUtils::build_complete_enumerated_literal(common_NODE_TERMINATING, detail_NODE_TERMINATING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_Status, literal_NODE_TERMINATING);
         }
-        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_Status, header_Status,
-            literal_seq_Status);
+        CompleteEnumeratedType enumerated_type_Status = TypeObjectUtils::build_complete_enumerated_type(enum_flags_Status, header_Status,
+                literal_seq_Status);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status,
-                type_name_Status.to_string(), type_ids_Status))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_Status, type_name_Status.to_string(), type_ids_Status))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "Status already registered in TypeObjectRegistry for a different type.");
+                "Status already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_TaskStatus_type_identifier(
+}void register_TaskStatus_type_identifier(
         TypeIdentifierPair& type_ids_TaskStatus)
 {
     ReturnCode_t return_code_TaskStatus {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskStatus =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskStatus", type_ids_TaskStatus);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskStatus)
     {
         EnumTypeFlag enum_flags_TaskStatus = 0;
         BitBound bit_bound_TaskStatus = 32;
-        CommonEnumeratedHeader common_TaskStatus =
-                TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
+        CommonEnumeratedHeader common_TaskStatus = TypeObjectUtils::build_common_enumerated_header(bit_bound_TaskStatus);
         QualifiedTypeName type_name_TaskStatus = "TaskStatus";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskStatus;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskStatus;
-        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus,
-                        ann_custom_TaskStatus,
-                        type_name_TaskStatus.to_string());
-        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(
-            common_TaskStatus, detail_TaskStatus);
+        CompleteTypeDetail detail_TaskStatus = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskStatus, ann_custom_TaskStatus, type_name_TaskStatus.to_string());
+        CompleteEnumeratedHeader header_TaskStatus = TypeObjectUtils::build_complete_enumerated_header(common_TaskStatus, detail_TaskStatus);
         CompleteEnumeratedLiteralSeq literal_seq_TaskStatus;
         {
             EnumeratedLiteralFlag flags_TASK_WAITING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_TASK_WAITING);
+            CommonEnumeratedLiteral common_TASK_WAITING = TypeObjectUtils::build_common_enumerated_literal(0, flags_TASK_WAITING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_WAITING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_WAITING = "TASK_WAITING";
-            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING,
-                            member_ann_builtin_TASK_WAITING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_WAITING, detail_TASK_WAITING);
+            CompleteMemberDetail detail_TASK_WAITING = TypeObjectUtils::build_complete_member_detail(name_TASK_WAITING, member_ann_builtin_TASK_WAITING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_WAITING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_WAITING, detail_TASK_WAITING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_WAITING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_TASK_ERROR);
+            CommonEnumeratedLiteral common_TASK_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_TASK_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_ERROR;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_ERROR = "TASK_ERROR";
-            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR,
-                            member_ann_builtin_TASK_ERROR,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_ERROR, detail_TASK_ERROR);
+            CompleteMemberDetail detail_TASK_ERROR = TypeObjectUtils::build_complete_member_detail(name_TASK_ERROR, member_ann_builtin_TASK_ERROR, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_ERROR, detail_TASK_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_TASK_RUNNING = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_TASK_RUNNING);
+            CommonEnumeratedLiteral common_TASK_RUNNING = TypeObjectUtils::build_common_enumerated_literal(2, flags_TASK_RUNNING);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_RUNNING;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_RUNNING = "TASK_RUNNING";
-            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING,
-                            member_ann_builtin_TASK_RUNNING,
-                            ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_RUNNING, detail_TASK_RUNNING);
+            CompleteMemberDetail detail_TASK_RUNNING = TypeObjectUtils::build_complete_member_detail(name_TASK_RUNNING, member_ann_builtin_TASK_RUNNING, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_RUNNING = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_RUNNING, detail_TASK_RUNNING);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_RUNNING);
         }
         {
             EnumeratedLiteralFlag flags_TASK_SUCCEEDED = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_TASK_SUCCEEDED);
+            CommonEnumeratedLiteral common_TASK_SUCCEEDED = TypeObjectUtils::build_common_enumerated_literal(3, flags_TASK_SUCCEEDED);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TASK_SUCCEEDED;
             ann_custom_TaskStatus.reset();
             MemberName name_TASK_SUCCEEDED = "TASK_SUCCEEDED";
-            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(
-                name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
-            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
+            CompleteMemberDetail detail_TASK_SUCCEEDED = TypeObjectUtils::build_complete_member_detail(name_TASK_SUCCEEDED, member_ann_builtin_TASK_SUCCEEDED, ann_custom_TaskStatus);
+            CompleteEnumeratedLiteral literal_TASK_SUCCEEDED = TypeObjectUtils::build_complete_enumerated_literal(common_TASK_SUCCEEDED, detail_TASK_SUCCEEDED);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_TaskStatus, literal_TASK_SUCCEEDED);
         }
-        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_TaskStatus, header_TaskStatus,
-            literal_seq_TaskStatus);
+        CompleteEnumeratedType enumerated_type_TaskStatus = TypeObjectUtils::build_complete_enumerated_type(enum_flags_TaskStatus, header_TaskStatus,
+                literal_seq_TaskStatus);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus,
-                type_name_TaskStatus.to_string(), type_ids_TaskStatus))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_TaskStatus, type_name_TaskStatus.to_string(), type_ids_TaskStatus))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "TaskStatus already registered in TypeObjectRegistry for a different type.");
+                "TaskStatus already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_ErrorCode_type_identifier(
+}void register_ErrorCode_type_identifier(
         TypeIdentifierPair& type_ids_ErrorCode)
 {
     ReturnCode_t return_code_ErrorCode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_ErrorCode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "ErrorCode", type_ids_ErrorCode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_ErrorCode)
     {
@@ -261,72 +207,55 @@ void register_ErrorCode_type_identifier(
         QualifiedTypeName type_name_ErrorCode = "ErrorCode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ErrorCode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ErrorCode;
-        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode,
-                        ann_custom_ErrorCode,
-                        type_name_ErrorCode.to_string());
-        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode,
-                        detail_ErrorCode);
+        CompleteTypeDetail detail_ErrorCode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ErrorCode, ann_custom_ErrorCode, type_name_ErrorCode.to_string());
+        CompleteEnumeratedHeader header_ErrorCode = TypeObjectUtils::build_complete_enumerated_header(common_ErrorCode, detail_ErrorCode);
         CompleteEnumeratedLiteralSeq literal_seq_ErrorCode;
         {
             EnumeratedLiteralFlag flags_NO_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_ERROR =
-                    TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
+            CommonEnumeratedLiteral common_NO_ERROR = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_NO_ERROR = "NO_ERROR";
-            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR,
-                            member_ann_builtin_NO_ERROR,
-                            ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_ERROR, detail_NO_ERROR);
+            CompleteMemberDetail detail_NO_ERROR = TypeObjectUtils::build_complete_member_detail(name_NO_ERROR, member_ann_builtin_NO_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_NO_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_NO_ERROR, detail_NO_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_NO_ERROR);
         }
         {
             EnumeratedLiteralFlag flags_INTERNAL_ERROR = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_INTERNAL_ERROR);
+            CommonEnumeratedLiteral common_INTERNAL_ERROR = TypeObjectUtils::build_common_enumerated_literal(1, flags_INTERNAL_ERROR);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_INTERNAL_ERROR;
             ann_custom_ErrorCode.reset();
             MemberName name_INTERNAL_ERROR = "INTERNAL_ERROR";
-            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(
-                name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
-            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(
-                common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
+            CompleteMemberDetail detail_INTERNAL_ERROR = TypeObjectUtils::build_complete_member_detail(name_INTERNAL_ERROR, member_ann_builtin_INTERNAL_ERROR, ann_custom_ErrorCode);
+            CompleteEnumeratedLiteral literal_INTERNAL_ERROR = TypeObjectUtils::build_complete_enumerated_literal(common_INTERNAL_ERROR, detail_INTERNAL_ERROR);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_ErrorCode, literal_INTERNAL_ERROR);
         }
-        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_ErrorCode, header_ErrorCode,
-            literal_seq_ErrorCode);
+        CompleteEnumeratedType enumerated_type_ErrorCode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_ErrorCode, header_ErrorCode,
+                literal_seq_ErrorCode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode,
-                type_name_ErrorCode.to_string(), type_ids_ErrorCode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_ErrorCode, type_name_ErrorCode.to_string(), type_ids_ErrorCode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "ErrorCode already registered in TypeObjectRegistry for a different type.");
+                "ErrorCode already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_TaskIdImpl_type_identifier(
         TypeIdentifierPair& type_ids_TaskIdImpl)
 {
 
     ReturnCode_t return_code_TaskIdImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_TaskIdImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "TaskIdImpl", type_ids_TaskIdImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_TaskIdImpl)
     {
-        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_TaskIdImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_TaskIdImpl = "TaskIdImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_TaskIdImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_TaskIdImpl;
-        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl,
-                        ann_custom_TaskIdImpl,
-                        type_name_TaskIdImpl.to_string());
+        CompleteTypeDetail detail_TaskIdImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_TaskIdImpl, ann_custom_TaskIdImpl, type_name_TaskIdImpl.to_string());
         CompleteStructHeader header_TaskIdImpl;
         header_TaskIdImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_TaskIdImpl);
         CompleteStructMemberSeq member_seq_TaskIdImpl;
@@ -334,8 +263,7 @@ void register_TaskIdImpl_type_identifier(
             TypeIdentifierPair type_ids_problem_id;
             ReturnCode_t return_code_problem_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_problem_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_id)
@@ -344,37 +272,28 @@ void register_TaskIdImpl_type_identifier(
                         "problem_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_id = 0x00000000;
             bool common_problem_id_ec {false};
-            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id,
-                                                          member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_problem_id,
-                                                              common_problem_id_ec))};
+            CommonStructMember common_problem_id {TypeObjectUtils::build_common_struct_member(member_id_problem_id, member_flags_problem_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_id, common_problem_id_ec))};
             if (!common_problem_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_id = "problem_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id,
-                            member_ann_builtin_problem_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id,
-                            detail_problem_id);
+            CompleteMemberDetail detail_problem_id = TypeObjectUtils::build_complete_member_detail(name_problem_id, member_ann_builtin_problem_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_problem_id = TypeObjectUtils::build_complete_struct_member(common_problem_id, detail_problem_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_problem_id);
         }
         {
             TypeIdentifierPair type_ids_iteration_id;
             ReturnCode_t return_code_iteration_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_iteration_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_iteration_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_iteration_id)
@@ -383,44 +302,32 @@ void register_TaskIdImpl_type_identifier(
                         "iteration_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_iteration_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_iteration_id = 0x00000001;
             bool common_iteration_id_ec {false};
-            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id,
-                                                            member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_iteration_id,
-                                                                common_iteration_id_ec))};
+            CommonStructMember common_iteration_id {TypeObjectUtils::build_common_struct_member(member_id_iteration_id, member_flags_iteration_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_iteration_id, common_iteration_id_ec))};
             if (!common_iteration_id_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure iteration_id member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure iteration_id member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_iteration_id = "iteration_id";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_iteration_id;
             ann_custom_TaskIdImpl.reset();
-            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id,
-                            member_ann_builtin_iteration_id,
-                            ann_custom_TaskIdImpl);
-            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(
-                common_iteration_id, detail_iteration_id);
+            CompleteMemberDetail detail_iteration_id = TypeObjectUtils::build_complete_member_detail(name_iteration_id, member_ann_builtin_iteration_id, ann_custom_TaskIdImpl);
+            CompleteStructMember member_iteration_id = TypeObjectUtils::build_complete_struct_member(common_iteration_id, detail_iteration_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_TaskIdImpl, member_iteration_id);
         }
-        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl,
-                        header_TaskIdImpl,
-                        member_seq_TaskIdImpl);
+        CompleteStructType struct_type_TaskIdImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_TaskIdImpl, header_TaskIdImpl, member_seq_TaskIdImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl,
-                type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_TaskIdImpl, type_name_TaskIdImpl.to_string(), type_ids_TaskIdImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "TaskIdImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_NodeStatusImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeStatusImpl)
@@ -428,19 +335,16 @@ void register_NodeStatusImpl_type_identifier(
 
     ReturnCode_t return_code_NodeStatusImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeStatusImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeStatusImpl", type_ids_NodeStatusImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeStatusImpl)
     {
-        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeStatusImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeStatusImpl = "NodeStatusImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeStatusImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeStatusImpl;
-        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
+        CompleteTypeDetail detail_NodeStatusImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeStatusImpl, ann_custom_NodeStatusImpl, type_name_NodeStatusImpl.to_string());
         CompleteStructHeader header_NodeStatusImpl;
         header_NodeStatusImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeStatusImpl);
         CompleteStructMemberSeq member_seq_NodeStatusImpl;
@@ -448,119 +352,91 @@ void register_NodeStatusImpl_type_identifier(
             TypeIdentifierPair type_ids_node_status;
             ReturnCode_t return_code_node_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "Status", type_ids_node_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_status)
             {
-                ::register_Status_type_identifier(type_ids_node_status);
+            ::register_Status_type_identifier(type_ids_node_status);
             }
-            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_node_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_node_status = 0x00000000;
             bool common_node_status_ec {false};
-            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status,
-                                                           member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_node_status,
-                                                               common_node_status_ec))};
+            CommonStructMember common_node_status {TypeObjectUtils::build_common_struct_member(member_id_node_status, member_flags_node_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_status, common_node_status_ec))};
             if (!common_node_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_status = "node_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status,
-                            member_ann_builtin_node_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status,
-                            detail_node_status);
+            CompleteMemberDetail detail_node_status = TypeObjectUtils::build_complete_member_detail(name_node_status, member_ann_builtin_node_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_status = TypeObjectUtils::build_complete_struct_member(common_node_status, detail_node_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_status);
         }
         {
             TypeIdentifierPair type_ids_task_status;
             ReturnCode_t return_code_task_status {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_status =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskStatus", type_ids_task_status);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_status)
             {
-                ::register_TaskStatus_type_identifier(type_ids_task_status);
+            ::register_TaskStatus_type_identifier(type_ids_task_status);
             }
-            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_task_status = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_task_status = 0x00000001;
             bool common_task_status_ec {false};
-            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status,
-                                                           member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_task_status,
-                                                               common_task_status_ec))};
+            CommonStructMember common_task_status {TypeObjectUtils::build_common_struct_member(member_id_task_status, member_flags_task_status, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_status, common_task_status_ec))};
             if (!common_task_status_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure task_status member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_status member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_task_status = "task_status";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_task_status;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status,
-                            member_ann_builtin_task_status,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status,
-                            detail_task_status);
+            CompleteMemberDetail detail_task_status = TypeObjectUtils::build_complete_member_detail(name_task_status, member_ann_builtin_task_status, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_status = TypeObjectUtils::build_complete_struct_member(common_task_status, detail_task_status);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_status);
         }
         {
             TypeIdentifierPair type_ids_error_code;
             ReturnCode_t return_code_error_code {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_code =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "ErrorCode", type_ids_error_code);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_code)
             {
-                ::register_ErrorCode_type_identifier(type_ids_error_code);
+            ::register_ErrorCode_type_identifier(type_ids_error_code);
             }
-            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_code = 0x00000002;
             bool common_error_code_ec {false};
-            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code,
-                                                          member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_error_code,
-                                                              common_error_code_ec))};
+            CommonStructMember common_error_code {TypeObjectUtils::build_common_struct_member(member_id_error_code, member_flags_error_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_code, common_error_code_ec))};
             if (!common_error_code_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_code member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_code member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_code = "error_code";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_code;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code,
-                            member_ann_builtin_error_code,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code,
-                            detail_error_code);
+            CompleteMemberDetail detail_error_code = TypeObjectUtils::build_complete_member_detail(name_error_code, member_ann_builtin_error_code, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_code = TypeObjectUtils::build_complete_struct_member(common_error_code, detail_error_code);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_code);
         }
         {
             TypeIdentifierPair type_ids_error_description;
             ReturnCode_t return_code_error_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_error_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_error_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_error_description)
@@ -573,41 +449,32 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_error_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_error_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_error_description = 0x00000003;
             bool common_error_description_ec {false};
-            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_error_description,
-                                                             member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_error_description,
-                                                                 common_error_description_ec))};
+            CommonStructMember common_error_description {TypeObjectUtils::build_common_struct_member(member_id_error_description, member_flags_error_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_error_description, common_error_description_ec))};
             if (!common_error_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure error_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure error_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_error_description = "error_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_error_description;
             ann_custom_NodeStatusImpl.reset();
-            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(
-                name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
-            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(
-                common_error_description, detail_error_description);
+            CompleteMemberDetail detail_error_description = TypeObjectUtils::build_complete_member_detail(name_error_description, member_ann_builtin_error_description, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_error_description = TypeObjectUtils::build_complete_struct_member(common_error_description, detail_error_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_error_description);
         }
         {
             TypeIdentifierPair type_ids_node_name;
             ReturnCode_t return_code_node_name {eprosima::fastdds::dds::RETCODE_OK};
             return_code_node_name =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_node_name);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_name)
@@ -620,23 +487,18 @@ void register_NodeStatusImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_node_name))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_node_name = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_node_name = 0x00000004;
             bool common_node_name_ec {false};
-            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name,
-                                                         member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_node_name,
-                                                             common_node_name_ec))};
+            CommonStructMember common_node_name {TypeObjectUtils::build_common_struct_member(member_id_node_name, member_flags_node_name, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_name, common_node_name_ec))};
             if (!common_node_name_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure node_name member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_name member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_node_name = "node_name";
@@ -647,46 +509,34 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_node_name;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_node_name;
             eprosima::fastcdr::optional<std::string> hash_id_node_name;
-            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() ||
-                    hash_id_node_name.has_value())
+            if (unit_node_name.has_value() || min_node_name.has_value() || max_node_name.has_value() || hash_id_node_name.has_value())
             {
-                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name,
-                                min_node_name,
-                                max_node_name,
-                                hash_id_node_name);
+                member_ann_builtin_node_name = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_name, min_node_name, max_node_name, hash_id_node_name);
             }
             if (!tmp_ann_custom_node_name.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_node_name;
             }
-            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name,
-                            member_ann_builtin_node_name,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name,
-                            detail_node_name);
+            CompleteMemberDetail detail_node_name = TypeObjectUtils::build_complete_member_detail(name_node_name, member_ann_builtin_node_name, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_node_name = TypeObjectUtils::build_complete_struct_member(common_node_name, detail_node_name);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_node_name);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000005;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -700,44 +550,33 @@ void register_NodeStatusImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeStatusImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeStatusImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeStatusImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeStatusImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
+        CompleteStructType struct_type_NodeStatusImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeStatusImpl, header_NodeStatusImpl, member_seq_NodeStatusImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl,
-                type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeStatusImpl, type_name_NodeStatusImpl.to_string(), type_ids_NodeStatusImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeStatusImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 void register_CmdNode_type_identifier(
         TypeIdentifierPair& type_ids_CmdNode)
 {
     ReturnCode_t return_code_CmdNode {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdNode =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdNode", type_ids_CmdNode);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdNode)
     {
@@ -747,101 +586,74 @@ void register_CmdNode_type_identifier(
         QualifiedTypeName type_name_CmdNode = "CmdNode";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdNode;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdNode;
-        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode,
-                        ann_custom_CmdNode,
-                        type_name_CmdNode.to_string());
-        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode,
-                        detail_CmdNode);
+        CompleteTypeDetail detail_CmdNode = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdNode, ann_custom_CmdNode, type_name_CmdNode.to_string());
+        CompleteEnumeratedHeader header_CmdNode = TypeObjectUtils::build_complete_enumerated_header(common_CmdNode, detail_CmdNode);
         CompleteEnumeratedLiteralSeq literal_seq_CmdNode;
         {
             EnumeratedLiteralFlag flags_NO_CMD_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_NODE);
+            CommonEnumeratedLiteral common_NO_CMD_NODE = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_NO_CMD_NODE = "NO_CMD_NODE";
-            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE,
-                            member_ann_builtin_NO_CMD_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_NODE, detail_NO_CMD_NODE);
+            CompleteMemberDetail detail_NO_CMD_NODE = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_NODE, member_ann_builtin_NO_CMD_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_NO_CMD_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_NODE, detail_NO_CMD_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_NO_CMD_NODE);
         }
         {
             EnumeratedLiteralFlag flags_START_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_START_NODE);
+            CommonEnumeratedLiteral common_START_NODE = TypeObjectUtils::build_common_enumerated_literal(1, flags_START_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_START_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_START_NODE = "START_NODE";
-            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE,
-                            member_ann_builtin_START_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_START_NODE, detail_START_NODE);
+            CompleteMemberDetail detail_START_NODE = TypeObjectUtils::build_complete_member_detail(name_START_NODE, member_ann_builtin_START_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_START_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_START_NODE, detail_START_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_START_NODE);
         }
         {
             EnumeratedLiteralFlag flags_STOP_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_STOP_NODE);
+            CommonEnumeratedLiteral common_STOP_NODE = TypeObjectUtils::build_common_enumerated_literal(2, flags_STOP_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_STOP_NODE = "STOP_NODE";
-            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE,
-                            member_ann_builtin_STOP_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_NODE, detail_STOP_NODE);
+            CompleteMemberDetail detail_STOP_NODE = TypeObjectUtils::build_complete_member_detail(name_STOP_NODE, member_ann_builtin_STOP_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_STOP_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_NODE, detail_STOP_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_STOP_NODE);
         }
         {
             EnumeratedLiteralFlag flags_RESET_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_RESET_NODE);
+            CommonEnumeratedLiteral common_RESET_NODE = TypeObjectUtils::build_common_enumerated_literal(3, flags_RESET_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_RESET_NODE = "RESET_NODE";
-            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE,
-                            member_ann_builtin_RESET_NODE,
-                            ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_NODE, detail_RESET_NODE);
+            CompleteMemberDetail detail_RESET_NODE = TypeObjectUtils::build_complete_member_detail(name_RESET_NODE, member_ann_builtin_RESET_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_RESET_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_NODE, detail_RESET_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_RESET_NODE);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_NODE = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_NODE);
+            CommonEnumeratedLiteral common_TERMINATE_NODE = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_NODE);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_NODE;
             ann_custom_CmdNode.reset();
             MemberName name_TERMINATE_NODE = "TERMINATE_NODE";
-            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
-            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_NODE, detail_TERMINATE_NODE);
+            CompleteMemberDetail detail_TERMINATE_NODE = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_NODE, member_ann_builtin_TERMINATE_NODE, ann_custom_CmdNode);
+            CompleteEnumeratedLiteral literal_TERMINATE_NODE = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_NODE, detail_TERMINATE_NODE);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdNode, literal_TERMINATE_NODE);
         }
-        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdNode, header_CmdNode,
-            literal_seq_CmdNode);
+        CompleteEnumeratedType enumerated_type_CmdNode = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdNode, header_CmdNode,
+                literal_seq_CmdNode);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode,
-                type_name_CmdNode.to_string(), type_ids_CmdNode))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdNode, type_name_CmdNode.to_string(), type_ids_CmdNode))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdNode already registered in TypeObjectRegistry for a different type.");
+                "CmdNode already registered in TypeObjectRegistry for a different type.");
         }
     }
-}
-
-void register_CmdTask_type_identifier(
+}void register_CmdTask_type_identifier(
         TypeIdentifierPair& type_ids_CmdTask)
 {
     ReturnCode_t return_code_CmdTask {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CmdTask =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CmdTask", type_ids_CmdTask);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CmdTask)
     {
@@ -851,197 +663,149 @@ void register_CmdTask_type_identifier(
         QualifiedTypeName type_name_CmdTask = "CmdTask";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CmdTask;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CmdTask;
-        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask,
-                        ann_custom_CmdTask,
-                        type_name_CmdTask.to_string());
-        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask,
-                        detail_CmdTask);
+        CompleteTypeDetail detail_CmdTask = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CmdTask, ann_custom_CmdTask, type_name_CmdTask.to_string());
+        CompleteEnumeratedHeader header_CmdTask = TypeObjectUtils::build_complete_enumerated_header(common_CmdTask, detail_CmdTask);
         CompleteEnumeratedLiteralSeq literal_seq_CmdTask;
         {
             EnumeratedLiteralFlag flags_NO_CMD_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0,
-                            flags_NO_CMD_TASK);
+            CommonEnumeratedLiteral common_NO_CMD_TASK = TypeObjectUtils::build_common_enumerated_literal(0, flags_NO_CMD_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_NO_CMD_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_NO_CMD_TASK = "NO_CMD_TASK";
-            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK,
-                            member_ann_builtin_NO_CMD_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_NO_CMD_TASK, detail_NO_CMD_TASK);
+            CompleteMemberDetail detail_NO_CMD_TASK = TypeObjectUtils::build_complete_member_detail(name_NO_CMD_TASK, member_ann_builtin_NO_CMD_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_NO_CMD_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_NO_CMD_TASK, detail_NO_CMD_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_NO_CMD_TASK);
         }
         {
             EnumeratedLiteralFlag flags_STOP_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1,
-                            flags_STOP_TASK);
+            CommonEnumeratedLiteral common_STOP_TASK = TypeObjectUtils::build_common_enumerated_literal(1, flags_STOP_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_STOP_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_STOP_TASK = "STOP_TASK";
-            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK,
-                            member_ann_builtin_STOP_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_STOP_TASK, detail_STOP_TASK);
+            CompleteMemberDetail detail_STOP_TASK = TypeObjectUtils::build_complete_member_detail(name_STOP_TASK, member_ann_builtin_STOP_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_STOP_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_STOP_TASK, detail_STOP_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_STOP_TASK);
         }
         {
             EnumeratedLiteralFlag flags_RESET_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2,
-                            flags_RESET_TASK);
+            CommonEnumeratedLiteral common_RESET_TASK = TypeObjectUtils::build_common_enumerated_literal(2, flags_RESET_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_RESET_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_RESET_TASK = "RESET_TASK";
-            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK,
-                            member_ann_builtin_RESET_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_RESET_TASK, detail_RESET_TASK);
+            CompleteMemberDetail detail_RESET_TASK = TypeObjectUtils::build_complete_member_detail(name_RESET_TASK, member_ann_builtin_RESET_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_RESET_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_RESET_TASK, detail_RESET_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_RESET_TASK);
         }
         {
             EnumeratedLiteralFlag flags_PREEMPT_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3,
-                            flags_PREEMPT_TASK);
+            CommonEnumeratedLiteral common_PREEMPT_TASK = TypeObjectUtils::build_common_enumerated_literal(3, flags_PREEMPT_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_PREEMPT_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_PREEMPT_TASK = "PREEMPT_TASK";
-            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK,
-                            member_ann_builtin_PREEMPT_TASK,
-                            ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_PREEMPT_TASK, detail_PREEMPT_TASK);
+            CompleteMemberDetail detail_PREEMPT_TASK = TypeObjectUtils::build_complete_member_detail(name_PREEMPT_TASK, member_ann_builtin_PREEMPT_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_PREEMPT_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_PREEMPT_TASK, detail_PREEMPT_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_PREEMPT_TASK);
         }
         {
             EnumeratedLiteralFlag flags_TERMINATE_TASK = TypeObjectUtils::build_enumerated_literal_flag(false);
-            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4,
-                            flags_TERMINATE_TASK);
+            CommonEnumeratedLiteral common_TERMINATE_TASK = TypeObjectUtils::build_common_enumerated_literal(4, flags_TERMINATE_TASK);
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_TERMINATE_TASK;
             ann_custom_CmdTask.reset();
             MemberName name_TERMINATE_TASK = "TERMINATE_TASK";
-            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(
-                name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
-            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(
-                common_TERMINATE_TASK, detail_TERMINATE_TASK);
+            CompleteMemberDetail detail_TERMINATE_TASK = TypeObjectUtils::build_complete_member_detail(name_TERMINATE_TASK, member_ann_builtin_TERMINATE_TASK, ann_custom_CmdTask);
+            CompleteEnumeratedLiteral literal_TERMINATE_TASK = TypeObjectUtils::build_complete_enumerated_literal(common_TERMINATE_TASK, detail_TERMINATE_TASK);
             TypeObjectUtils::add_complete_enumerated_literal(literal_seq_CmdTask, literal_TERMINATE_TASK);
         }
-        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(
-            enum_flags_CmdTask, header_CmdTask,
-            literal_seq_CmdTask);
+        CompleteEnumeratedType enumerated_type_CmdTask = TypeObjectUtils::build_complete_enumerated_type(enum_flags_CmdTask, header_CmdTask,
+                literal_seq_CmdTask);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask,
-                type_name_CmdTask.to_string(), type_ids_CmdTask))
+                TypeObjectUtils::build_and_register_enumerated_type_object(enumerated_type_CmdTask, type_name_CmdTask.to_string(), type_ids_CmdTask))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                    "CmdTask already registered in TypeObjectRegistry for a different type.");
+                "CmdTask already registered in TypeObjectRegistry for a different type.");
         }
     }
 }// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
-
 void register_NodeControlImpl_type_identifier(
         TypeIdentifierPair& type_ids_NodeControlImpl)
 {
 
     ReturnCode_t return_code_NodeControlImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_NodeControlImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "NodeControlImpl", type_ids_NodeControlImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_NodeControlImpl)
     {
-        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_NodeControlImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_NodeControlImpl = "NodeControlImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_NodeControlImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_NodeControlImpl;
-        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
+        CompleteTypeDetail detail_NodeControlImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_NodeControlImpl, ann_custom_NodeControlImpl, type_name_NodeControlImpl.to_string());
         CompleteStructHeader header_NodeControlImpl;
-        header_NodeControlImpl =
-                TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
+        header_NodeControlImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_NodeControlImpl);
         CompleteStructMemberSeq member_seq_NodeControlImpl;
         {
             TypeIdentifierPair type_ids_cmd_node;
             ReturnCode_t return_code_cmd_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdNode", type_ids_cmd_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_node)
             {
-                ::register_CmdNode_type_identifier(type_ids_cmd_node);
+            ::register_CmdNode_type_identifier(type_ids_cmd_node);
             }
-            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_node = 0x00000000;
             bool common_cmd_node_ec {false};
-            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node,
-                                                        member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_node,
-                                                            common_cmd_node_ec))};
+            CommonStructMember common_cmd_node {TypeObjectUtils::build_common_struct_member(member_id_cmd_node, member_flags_cmd_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_node, common_cmd_node_ec))};
             if (!common_cmd_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_node = "cmd_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node,
-                            member_ann_builtin_cmd_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node,
-                            detail_cmd_node);
+            CompleteMemberDetail detail_cmd_node = TypeObjectUtils::build_complete_member_detail(name_cmd_node, member_ann_builtin_cmd_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_node = TypeObjectUtils::build_complete_struct_member(common_cmd_node, detail_cmd_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_node);
         }
         {
             TypeIdentifierPair type_ids_cmd_task;
             ReturnCode_t return_code_cmd_task {eprosima::fastdds::dds::RETCODE_OK};
             return_code_cmd_task =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "CmdTask", type_ids_cmd_task);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_cmd_task)
             {
-                ::register_CmdTask_type_identifier(type_ids_cmd_task);
+            ::register_CmdTask_type_identifier(type_ids_cmd_task);
             }
-            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_cmd_task = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_cmd_task = 0x00000001;
             bool common_cmd_task_ec {false};
-            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task,
-                                                        member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_cmd_task,
-                                                            common_cmd_task_ec))};
+            CommonStructMember common_cmd_task {TypeObjectUtils::build_common_struct_member(member_id_cmd_task, member_flags_cmd_task, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_cmd_task, common_cmd_task_ec))};
             if (!common_cmd_task_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure cmd_task member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure cmd_task member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_cmd_task = "cmd_task";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_cmd_task;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task,
-                            member_ann_builtin_cmd_task,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task,
-                            detail_cmd_task);
+            CompleteMemberDetail detail_cmd_task = TypeObjectUtils::build_complete_member_detail(name_cmd_task, member_ann_builtin_cmd_task, ann_custom_NodeControlImpl);
+            CompleteStructMember member_cmd_task = TypeObjectUtils::build_complete_struct_member(common_cmd_task, detail_cmd_task);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_cmd_task);
         }
         {
             TypeIdentifierPair type_ids_target_node;
             ReturnCode_t return_code_target_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_target_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_node)
@@ -1054,41 +818,32 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_target_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_node = 0x00000002;
             bool common_target_node_ec {false};
-            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node,
-                                                           member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_target_node,
-                                                               common_target_node_ec))};
+            CommonStructMember common_target_node {TypeObjectUtils::build_common_struct_member(member_id_target_node, member_flags_target_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_node, common_target_node_ec))};
             if (!common_target_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_node = "target_node";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_node;
             ann_custom_NodeControlImpl.reset();
-            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node,
-                            member_ann_builtin_target_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node,
-                            detail_target_node);
+            CompleteMemberDetail detail_target_node = TypeObjectUtils::build_complete_member_detail(name_target_node, member_ann_builtin_target_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_target_node = TypeObjectUtils::build_complete_struct_member(common_target_node, detail_target_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_target_node);
         }
         {
             TypeIdentifierPair type_ids_source_node;
             ReturnCode_t return_code_source_node {eprosima::fastdds::dds::RETCODE_OK};
             return_code_source_node =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_source_node);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_source_node)
@@ -1101,23 +856,18 @@ void register_NodeControlImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_source_node))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_source_node = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_source_node = 0x00000003;
             bool common_source_node_ec {false};
-            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node,
-                                                           member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_source_node,
-                                                               common_source_node_ec))};
+            CommonStructMember common_source_node {TypeObjectUtils::build_common_struct_member(member_id_source_node, member_flags_source_node, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_source_node, common_source_node_ec))};
             if (!common_source_node_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure source_node member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure source_node member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_source_node = "source_node";
@@ -1128,44 +878,34 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_source_node;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_source_node;
             eprosima::fastcdr::optional<std::string> hash_id_source_node;
-            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() ||
-                    hash_id_source_node.has_value())
+            if (unit_source_node.has_value() || min_source_node.has_value() || max_source_node.has_value() || hash_id_source_node.has_value())
             {
-                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(
-                    unit_source_node, min_source_node, max_source_node, hash_id_source_node);
+                member_ann_builtin_source_node = TypeObjectUtils::build_applied_builtin_member_annotations(unit_source_node, min_source_node, max_source_node, hash_id_source_node);
             }
             if (!tmp_ann_custom_source_node.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_source_node;
             }
-            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node,
-                            member_ann_builtin_source_node,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node,
-                            detail_source_node);
+            CompleteMemberDetail detail_source_node = TypeObjectUtils::build_complete_member_detail(name_source_node, member_ann_builtin_source_node, ann_custom_NodeControlImpl);
+            CompleteStructMember member_source_node = TypeObjectUtils::build_complete_struct_member(common_source_node, detail_source_node);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_source_node);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1179,37 +919,27 @@ void register_NodeControlImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_NodeControlImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_NodeControlImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_NodeControlImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_NodeControlImpl, member_task_id);
         }
-        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
+        CompleteStructType struct_type_NodeControlImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_NodeControlImpl, header_NodeControlImpl, member_seq_NodeControlImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl,
-                type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_NodeControlImpl, type_name_NodeControlImpl.to_string(), type_ids_NodeControlImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "NodeControlImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_UserInputImpl_type_identifier(
         TypeIdentifierPair& type_ids_UserInputImpl)
@@ -1217,19 +947,16 @@ void register_UserInputImpl_type_identifier(
 
     ReturnCode_t return_code_UserInputImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_UserInputImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "UserInputImpl", type_ids_UserInputImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_UserInputImpl)
     {
-        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_UserInputImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_UserInputImpl = "UserInputImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_UserInputImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_UserInputImpl;
-        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
+        CompleteTypeDetail detail_UserInputImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_UserInputImpl, ann_custom_UserInputImpl, type_name_UserInputImpl.to_string());
         CompleteStructHeader header_UserInputImpl;
         header_UserInputImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_UserInputImpl);
         CompleteStructMemberSeq member_seq_UserInputImpl;
@@ -1237,8 +964,7 @@ void register_UserInputImpl_type_identifier(
             TypeIdentifierPair type_ids_modality;
             ReturnCode_t return_code_modality {eprosima::fastdds::dds::RETCODE_OK};
             return_code_modality =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_modality);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_modality)
@@ -1251,41 +977,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_modality))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_modality = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_modality = 0x00000000;
             bool common_modality_ec {false};
-            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality,
-                                                        member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_modality,
-                                                            common_modality_ec))};
+            CommonStructMember common_modality {TypeObjectUtils::build_common_struct_member(member_id_modality, member_flags_modality, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_modality, common_modality_ec))};
             if (!common_modality_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure modality member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure modality member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_modality = "modality";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_modality;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality,
-                            member_ann_builtin_modality,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality,
-                            detail_modality);
+            CompleteMemberDetail detail_modality = TypeObjectUtils::build_complete_member_detail(name_modality, member_ann_builtin_modality, ann_custom_UserInputImpl);
+            CompleteStructMember member_modality = TypeObjectUtils::build_complete_struct_member(common_modality, detail_modality);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_modality);
         }
         {
             TypeIdentifierPair type_ids_problem_short_description;
             ReturnCode_t return_code_problem_short_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_short_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_short_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_short_description)
@@ -1298,42 +1015,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_short_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_short_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_short_description = 0x00000001;
             bool common_problem_short_description_ec {false};
-            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(
-                                                                     member_id_problem_short_description,
-                                                                     member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                         type_ids_problem_short_description,
-                                                                         common_problem_short_description_ec))};
+            CommonStructMember common_problem_short_description {TypeObjectUtils::build_common_struct_member(member_id_problem_short_description, member_flags_problem_short_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_short_description, common_problem_short_description_ec))};
             if (!common_problem_short_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_short_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_short_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_short_description = "problem_short_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_short_description;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(
-                name_problem_short_description, member_ann_builtin_problem_short_description,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(
-                common_problem_short_description, detail_problem_short_description);
+            CompleteMemberDetail detail_problem_short_description = TypeObjectUtils::build_complete_member_detail(name_problem_short_description, member_ann_builtin_problem_short_description, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_short_description = TypeObjectUtils::build_complete_struct_member(common_problem_short_description, detail_problem_short_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_short_description);
         }
         {
             TypeIdentifierPair type_ids_problem_definition;
             ReturnCode_t return_code_problem_definition {eprosima::fastdds::dds::RETCODE_OK};
             return_code_problem_definition =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_problem_definition);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_problem_definition)
@@ -1346,48 +1053,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_problem_definition))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_problem_definition = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_problem_definition = 0x00000002;
             bool common_problem_definition_ec {false};
-            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_problem_definition,
-                                                              member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_problem_definition,
-                                                                  common_problem_definition_ec))};
+            CommonStructMember common_problem_definition {TypeObjectUtils::build_common_struct_member(member_id_problem_definition, member_flags_problem_definition, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_problem_definition, common_problem_definition_ec))};
             if (!common_problem_definition_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure problem_definition member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure problem_definition member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_problem_definition = "problem_definition";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_problem_definition;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(
-                name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
-            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(
-                common_problem_definition, detail_problem_definition);
+            CompleteMemberDetail detail_problem_definition = TypeObjectUtils::build_complete_member_detail(name_problem_definition, member_ann_builtin_problem_definition, ann_custom_UserInputImpl);
+            CompleteStructMember member_problem_definition = TypeObjectUtils::build_complete_struct_member(common_problem_definition, detail_problem_definition);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_problem_definition);
         }
         {
             TypeIdentifierPair type_ids_inputs;
             ReturnCode_t return_code_inputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_inputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
             {
                 return_code_inputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_inputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_inputs)
@@ -1400,15 +1097,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_inputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_inputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1420,34 +1114,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_inputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_inputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_inputs = 0x00000003;
             bool common_inputs_ec {false};
-            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs,
-                                                      member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                          type_ids_inputs,
-                                                          common_inputs_ec))};
+            CommonStructMember common_inputs {TypeObjectUtils::build_common_struct_member(member_id_inputs, member_flags_inputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_inputs, common_inputs_ec))};
             if (!common_inputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure inputs member TypeIdentifier inconsistent.");
@@ -1456,26 +1140,21 @@ void register_UserInputImpl_type_identifier(
             MemberName name_inputs = "inputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_inputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs,
-                            member_ann_builtin_inputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs,
-                            detail_inputs);
+            CompleteMemberDetail detail_inputs = TypeObjectUtils::build_complete_member_detail(name_inputs, member_ann_builtin_inputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_inputs = TypeObjectUtils::build_complete_struct_member(common_inputs, detail_inputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_inputs);
         }
         {
             TypeIdentifierPair type_ids_outputs;
             ReturnCode_t return_code_outputs {eprosima::fastdds::dds::RETCODE_OK};
             return_code_outputs =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
             {
                 return_code_outputs =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_outputs);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_outputs)
@@ -1488,15 +1167,12 @@ void register_UserInputImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_outputs))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_outputs,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1508,34 +1184,24 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_outputs))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_outputs = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_outputs = 0x00000004;
             bool common_outputs_ec {false};
-            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs,
-                                                       member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_outputs,
-                                                           common_outputs_ec))};
+            CommonStructMember common_outputs {TypeObjectUtils::build_common_struct_member(member_id_outputs, member_flags_outputs, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_outputs, common_outputs_ec))};
             if (!common_outputs_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure outputs member TypeIdentifier inconsistent.");
@@ -1544,19 +1210,15 @@ void register_UserInputImpl_type_identifier(
             MemberName name_outputs = "outputs";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_outputs;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs,
-                            member_ann_builtin_outputs,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs,
-                            detail_outputs);
+            CompleteMemberDetail detail_outputs = TypeObjectUtils::build_complete_member_detail(name_outputs, member_ann_builtin_outputs, ann_custom_UserInputImpl);
+            CompleteStructMember member_outputs = TypeObjectUtils::build_complete_struct_member(common_outputs, detail_outputs);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_outputs);
         }
         {
             TypeIdentifierPair type_ids_minimum_samples;
             ReturnCode_t return_code_minimum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_minimum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_minimum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_minimum_samples)
@@ -1565,36 +1227,28 @@ void register_UserInputImpl_type_identifier(
                         "minimum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_minimum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_minimum_samples = 0x00000005;
             bool common_minimum_samples_ec {false};
-            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_minimum_samples,
-                                                               common_minimum_samples_ec))};
+            CommonStructMember common_minimum_samples {TypeObjectUtils::build_common_struct_member(member_id_minimum_samples, member_flags_minimum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_minimum_samples, common_minimum_samples_ec))};
             if (!common_minimum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure minimum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure minimum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_minimum_samples = "minimum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_minimum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_minimum_samples, detail_minimum_samples);
+            CompleteMemberDetail detail_minimum_samples = TypeObjectUtils::build_complete_member_detail(name_minimum_samples, member_ann_builtin_minimum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_minimum_samples = TypeObjectUtils::build_complete_struct_member(common_minimum_samples, detail_minimum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_minimum_samples);
         }
         {
             TypeIdentifierPair type_ids_maximum_samples;
             ReturnCode_t return_code_maximum_samples {eprosima::fastdds::dds::RETCODE_OK};
             return_code_maximum_samples =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_maximum_samples);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_maximum_samples)
@@ -1603,36 +1257,28 @@ void register_UserInputImpl_type_identifier(
                         "maximum_samples Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_maximum_samples = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_maximum_samples = 0x00000006;
             bool common_maximum_samples_ec {false};
-            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(
-                                                           member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_maximum_samples,
-                                                               common_maximum_samples_ec))};
+            CommonStructMember common_maximum_samples {TypeObjectUtils::build_common_struct_member(member_id_maximum_samples, member_flags_maximum_samples, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_maximum_samples, common_maximum_samples_ec))};
             if (!common_maximum_samples_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure maximum_samples member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure maximum_samples member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_maximum_samples = "maximum_samples";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_maximum_samples;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(
-                name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
-            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(
-                common_maximum_samples, detail_maximum_samples);
+            CompleteMemberDetail detail_maximum_samples = TypeObjectUtils::build_complete_member_detail(name_maximum_samples, member_ann_builtin_maximum_samples, ann_custom_UserInputImpl);
+            CompleteStructMember member_maximum_samples = TypeObjectUtils::build_complete_struct_member(common_maximum_samples, detail_maximum_samples);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_maximum_samples);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_manual;
             ReturnCode_t return_code_optimize_carbon_footprint_manual {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_manual =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_manual);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_manual)
@@ -1641,42 +1287,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_manual Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_manual = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_manual = 0x00000007;
             bool common_optimize_carbon_footprint_manual_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(
-                                                                            member_id_optimize_carbon_footprint_manual,
-                                                                            member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                type_ids_optimize_carbon_footprint_manual,
-                                                                                common_optimize_carbon_footprint_manual_ec))};
+            CommonStructMember common_optimize_carbon_footprint_manual {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_manual, member_flags_optimize_carbon_footprint_manual, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_manual, common_optimize_carbon_footprint_manual_ec))};
             if (!common_optimize_carbon_footprint_manual_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_manual member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_manual = "optimize_carbon_footprint_manual";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_manual;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_manual;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual,
-                            member_ann_builtin_optimize_carbon_footprint_manual,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_manual =
-                    TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual,
-                            detail_optimize_carbon_footprint_manual);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_manual);
+            CompleteMemberDetail detail_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_manual, member_ann_builtin_optimize_carbon_footprint_manual, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_manual = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_manual, detail_optimize_carbon_footprint_manual);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_manual);
         }
         {
             TypeIdentifierPair type_ids_previous_iteration;
             ReturnCode_t return_code_previous_iteration {eprosima::fastdds::dds::RETCODE_OK};
             return_code_previous_iteration =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_int32_t", type_ids_previous_iteration);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_previous_iteration)
@@ -1685,37 +1317,28 @@ void register_UserInputImpl_type_identifier(
                         "previous_iteration Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_previous_iteration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_previous_iteration = 0x00000008;
             bool common_previous_iteration_ec {false};
-            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_previous_iteration,
-                                                              member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_previous_iteration,
-                                                                  common_previous_iteration_ec))};
+            CommonStructMember common_previous_iteration {TypeObjectUtils::build_common_struct_member(member_id_previous_iteration, member_flags_previous_iteration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_previous_iteration, common_previous_iteration_ec))};
             if (!common_previous_iteration_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure previous_iteration member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure previous_iteration member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_previous_iteration = "previous_iteration";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_previous_iteration;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(
-                name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
-            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(
-                common_previous_iteration, detail_previous_iteration);
+            CompleteMemberDetail detail_previous_iteration = TypeObjectUtils::build_complete_member_detail(name_previous_iteration, member_ann_builtin_previous_iteration, ann_custom_UserInputImpl);
+            CompleteStructMember member_previous_iteration = TypeObjectUtils::build_complete_struct_member(common_previous_iteration, detail_previous_iteration);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_previous_iteration);
         }
         {
             TypeIdentifierPair type_ids_optimize_carbon_footprint_auto;
             ReturnCode_t return_code_optimize_carbon_footprint_auto {eprosima::fastdds::dds::RETCODE_OK};
             return_code_optimize_carbon_footprint_auto =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_bool", type_ids_optimize_carbon_footprint_auto);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_optimize_carbon_footprint_auto)
@@ -1724,40 +1347,28 @@ void register_UserInputImpl_type_identifier(
                         "optimize_carbon_footprint_auto Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_optimize_carbon_footprint_auto = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_optimize_carbon_footprint_auto = 0x00000009;
             bool common_optimize_carbon_footprint_auto_ec {false};
-            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(
-                                                                          member_id_optimize_carbon_footprint_auto,
-                                                                          member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                              type_ids_optimize_carbon_footprint_auto,
-                                                                              common_optimize_carbon_footprint_auto_ec))};
+            CommonStructMember common_optimize_carbon_footprint_auto {TypeObjectUtils::build_common_struct_member(member_id_optimize_carbon_footprint_auto, member_flags_optimize_carbon_footprint_auto, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_optimize_carbon_footprint_auto, common_optimize_carbon_footprint_auto_ec))};
             if (!common_optimize_carbon_footprint_auto_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure optimize_carbon_footprint_auto member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_optimize_carbon_footprint_auto = "optimize_carbon_footprint_auto";
-            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations>
-            member_ann_builtin_optimize_carbon_footprint_auto;
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_optimize_carbon_footprint_auto;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(
-                name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(
-                common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
-            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl,
-                    member_optimize_carbon_footprint_auto);
+            CompleteMemberDetail detail_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_member_detail(name_optimize_carbon_footprint_auto, member_ann_builtin_optimize_carbon_footprint_auto, ann_custom_UserInputImpl);
+            CompleteStructMember member_optimize_carbon_footprint_auto = TypeObjectUtils::build_complete_struct_member(common_optimize_carbon_footprint_auto, detail_optimize_carbon_footprint_auto);
+            TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_optimize_carbon_footprint_auto);
         }
         {
             TypeIdentifierPair type_ids_desired_carbon_footprint;
             ReturnCode_t return_code_desired_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_desired_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_desired_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_desired_carbon_footprint)
@@ -1766,38 +1377,28 @@ void register_UserInputImpl_type_identifier(
                         "desired_carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_desired_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_desired_carbon_footprint = 0x0000000a;
             bool common_desired_carbon_footprint_ec {false};
-            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                    member_id_desired_carbon_footprint,
-                                                                    member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                        type_ids_desired_carbon_footprint,
-                                                                        common_desired_carbon_footprint_ec))};
+            CommonStructMember common_desired_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_desired_carbon_footprint, member_flags_desired_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_desired_carbon_footprint, common_desired_carbon_footprint_ec))};
             if (!common_desired_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure desired_carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_desired_carbon_footprint = "desired_carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_desired_carbon_footprint;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint,
-                ann_custom_UserInputImpl);
-            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_desired_carbon_footprint, detail_desired_carbon_footprint);
+            CompleteMemberDetail detail_desired_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_desired_carbon_footprint, member_ann_builtin_desired_carbon_footprint, ann_custom_UserInputImpl);
+            CompleteStructMember member_desired_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_desired_carbon_footprint, detail_desired_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_desired_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_geo_location_continent;
             ReturnCode_t return_code_geo_location_continent {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_continent =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_continent);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_continent)
@@ -1810,41 +1411,32 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_continent))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_continent = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_continent = 0x0000000b;
             bool common_geo_location_continent_ec {false};
-            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(
-                                                                  member_id_geo_location_continent,
-                                                                  member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                      type_ids_geo_location_continent,
-                                                                      common_geo_location_continent_ec))};
+            CommonStructMember common_geo_location_continent {TypeObjectUtils::build_common_struct_member(member_id_geo_location_continent, member_flags_geo_location_continent, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_continent, common_geo_location_continent_ec))};
             if (!common_geo_location_continent_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_continent member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_continent member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_continent = "geo_location_continent";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_continent;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_continent, detail_geo_location_continent);
+            CompleteMemberDetail detail_geo_location_continent = TypeObjectUtils::build_complete_member_detail(name_geo_location_continent, member_ann_builtin_geo_location_continent, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_continent = TypeObjectUtils::build_complete_struct_member(common_geo_location_continent, detail_geo_location_continent);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_continent);
         }
         {
             TypeIdentifierPair type_ids_geo_location_region;
             ReturnCode_t return_code_geo_location_region {eprosima::fastdds::dds::RETCODE_OK};
             return_code_geo_location_region =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_geo_location_region);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_geo_location_region)
@@ -1857,48 +1449,38 @@ void register_UserInputImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_geo_location_region))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_geo_location_region = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_geo_location_region = 0x0000000c;
             bool common_geo_location_region_ec {false};
-            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(
-                                                               member_id_geo_location_region,
-                                                               member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                   type_ids_geo_location_region,
-                                                                   common_geo_location_region_ec))};
+            CommonStructMember common_geo_location_region {TypeObjectUtils::build_common_struct_member(member_id_geo_location_region, member_flags_geo_location_region, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_geo_location_region, common_geo_location_region_ec))};
             if (!common_geo_location_region_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure geo_location_region member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure geo_location_region member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_geo_location_region = "geo_location_region";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_geo_location_region;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(
-                name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
-            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(
-                common_geo_location_region, detail_geo_location_region);
+            CompleteMemberDetail detail_geo_location_region = TypeObjectUtils::build_complete_member_detail(name_geo_location_region, member_ann_builtin_geo_location_region, ann_custom_UserInputImpl);
+            CompleteStructMember member_geo_location_region = TypeObjectUtils::build_complete_struct_member(common_geo_location_region, detail_geo_location_region);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_geo_location_region);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -1908,9 +1490,7 @@ void register_UserInputImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -1922,70 +1502,52 @@ void register_UserInputImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x0000000d;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_UserInputImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_UserInputImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x0000000e;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -1999,37 +1561,27 @@ void register_UserInputImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_UserInputImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_UserInputImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_UserInputImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_UserInputImpl, member_task_id);
         }
-        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
+        CompleteStructType struct_type_UserInputImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_UserInputImpl, header_UserInputImpl, member_seq_UserInputImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl,
-                type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_UserInputImpl, type_name_UserInputImpl.to_string(), type_ids_UserInputImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "UserInputImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelMetadataImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelMetadataImpl)
@@ -2037,37 +1589,30 @@ void register_MLModelMetadataImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelMetadataImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelMetadataImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelMetadataImpl", type_ids_MLModelMetadataImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelMetadataImpl)
     {
-        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelMetadataImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelMetadataImpl = "MLModelMetadataImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelMetadataImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelMetadataImpl;
-        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl,
-            type_name_MLModelMetadataImpl.to_string());
+        CompleteTypeDetail detail_MLModelMetadataImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelMetadataImpl, ann_custom_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string());
         CompleteStructHeader header_MLModelMetadataImpl;
-        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_MLModelMetadataImpl);
+        header_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelMetadataImpl);
         CompleteStructMemberSeq member_seq_MLModelMetadataImpl;
         {
             TypeIdentifierPair type_ids_keywords;
             ReturnCode_t return_code_keywords {eprosima::fastdds::dds::RETCODE_OK};
             return_code_keywords =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
             {
                 return_code_keywords =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_keywords);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_keywords)
@@ -2080,15 +1625,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_keywords))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_keywords,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2100,63 +1642,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_keywords))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_keywords = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_keywords = 0x00000000;
             bool common_keywords_ec {false};
-            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords,
-                                                        member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                            type_ids_keywords,
-                                                            common_keywords_ec))};
+            CommonStructMember common_keywords {TypeObjectUtils::build_common_struct_member(member_id_keywords, member_flags_keywords, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_keywords, common_keywords_ec))};
             if (!common_keywords_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure keywords member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure keywords member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_keywords = "keywords";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_keywords;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords,
-                            member_ann_builtin_keywords,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords,
-                            detail_keywords);
+            CompleteMemberDetail detail_keywords = TypeObjectUtils::build_complete_member_detail(name_keywords, member_ann_builtin_keywords, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_keywords = TypeObjectUtils::build_complete_struct_member(common_keywords, detail_keywords);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_keywords);
         }
         {
             TypeIdentifierPair type_ids_ml_model_metadata;
             ReturnCode_t return_code_ml_model_metadata {eprosima::fastdds::dds::RETCODE_OK};
             return_code_ml_model_metadata =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
             {
                 return_code_ml_model_metadata =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_ml_model_metadata);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_ml_model_metadata)
@@ -2169,15 +1695,12 @@ void register_MLModelMetadataImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_ml_model_metadata))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_ml_model_metadata,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2189,63 +1712,47 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_ml_model_metadata))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_ml_model_metadata = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_ml_model_metadata = 0x00000001;
             bool common_ml_model_metadata_ec {false};
-            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_ml_model_metadata,
-                                                             member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_ml_model_metadata,
-                                                                 common_ml_model_metadata_ec))};
+            CommonStructMember common_ml_model_metadata {TypeObjectUtils::build_common_struct_member(member_id_ml_model_metadata, member_flags_ml_model_metadata, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_ml_model_metadata, common_ml_model_metadata_ec))};
             if (!common_ml_model_metadata_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure ml_model_metadata member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure ml_model_metadata member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_ml_model_metadata = "ml_model_metadata";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_ml_model_metadata;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(
-                name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(
-                common_ml_model_metadata, detail_ml_model_metadata);
+            CompleteMemberDetail detail_ml_model_metadata = TypeObjectUtils::build_complete_member_detail(name_ml_model_metadata, member_ann_builtin_ml_model_metadata, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_ml_model_metadata = TypeObjectUtils::build_complete_struct_member(common_ml_model_metadata, detail_ml_model_metadata);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_ml_model_metadata);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2255,9 +1762,7 @@ void register_MLModelMetadataImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2269,70 +1774,52 @@ void register_MLModelMetadataImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelMetadataImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2346,37 +1833,27 @@ void register_MLModelMetadataImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelMetadataImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelMetadataImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelMetadataImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelMetadataImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
+        CompleteStructType struct_type_MLModelMetadataImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelMetadataImpl, header_MLModelMetadataImpl, member_seq_MLModelMetadataImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl,
-                type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelMetadataImpl, type_name_MLModelMetadataImpl.to_string(), type_ids_MLModelMetadataImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelMetadataImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_AppRequirementsImpl_type_identifier(
         TypeIdentifierPair& type_ids_AppRequirementsImpl)
@@ -2384,37 +1861,30 @@ void register_AppRequirementsImpl_type_identifier(
 
     ReturnCode_t return_code_AppRequirementsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_AppRequirementsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "AppRequirementsImpl", type_ids_AppRequirementsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_AppRequirementsImpl)
     {
-        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_AppRequirementsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_AppRequirementsImpl = "AppRequirementsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_AppRequirementsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_AppRequirementsImpl;
-        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl,
-            type_name_AppRequirementsImpl.to_string());
+        CompleteTypeDetail detail_AppRequirementsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_AppRequirementsImpl, ann_custom_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string());
         CompleteStructHeader header_AppRequirementsImpl;
-        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_AppRequirementsImpl);
+        header_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_AppRequirementsImpl);
         CompleteStructMemberSeq member_seq_AppRequirementsImpl;
         {
             TypeIdentifierPair type_ids_app_requirements;
             ReturnCode_t return_code_app_requirements {eprosima::fastdds::dds::RETCODE_OK};
             return_code_app_requirements =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
             {
                 return_code_app_requirements =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_app_requirements);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_app_requirements)
@@ -2427,15 +1897,12 @@ void register_AppRequirementsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_app_requirements))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_app_requirements,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2447,62 +1914,47 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_app_requirements))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_app_requirements = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_app_requirements = 0x00000000;
             bool common_app_requirements_ec {false};
-            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_app_requirements,
-                                                                common_app_requirements_ec))};
+            CommonStructMember common_app_requirements {TypeObjectUtils::build_common_struct_member(member_id_app_requirements, member_flags_app_requirements, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_app_requirements, common_app_requirements_ec))};
             if (!common_app_requirements_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure app_requirements member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure app_requirements member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_app_requirements = "app_requirements";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_app_requirements;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(
-                name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(
-                common_app_requirements, detail_app_requirements);
+            CompleteMemberDetail detail_app_requirements = TypeObjectUtils::build_complete_member_detail(name_app_requirements, member_ann_builtin_app_requirements, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_app_requirements = TypeObjectUtils::build_complete_struct_member(common_app_requirements, detail_app_requirements);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_app_requirements);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2512,9 +1964,7 @@ void register_AppRequirementsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2526,70 +1976,52 @@ void register_AppRequirementsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000001;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_AppRequirementsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000002;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2603,37 +2035,27 @@ void register_AppRequirementsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_AppRequirementsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_AppRequirementsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_AppRequirementsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_AppRequirementsImpl, member_task_id);
         }
-        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
+        CompleteStructType struct_type_AppRequirementsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_AppRequirementsImpl, header_AppRequirementsImpl, member_seq_AppRequirementsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl,
-                type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_AppRequirementsImpl, type_name_AppRequirementsImpl.to_string(), type_ids_AppRequirementsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "AppRequirementsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWConstraintsImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWConstraintsImpl)
@@ -2641,30 +2063,24 @@ void register_HWConstraintsImpl_type_identifier(
 
     ReturnCode_t return_code_HWConstraintsImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWConstraintsImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWConstraintsImpl", type_ids_HWConstraintsImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWConstraintsImpl)
     {
-        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWConstraintsImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWConstraintsImpl = "HWConstraintsImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWConstraintsImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWConstraintsImpl;
-        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl,
-            type_name_HWConstraintsImpl.to_string());
+        CompleteTypeDetail detail_HWConstraintsImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWConstraintsImpl, ann_custom_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string());
         CompleteStructHeader header_HWConstraintsImpl;
-        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_HWConstraintsImpl);
+        header_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWConstraintsImpl);
         CompleteStructMemberSeq member_seq_HWConstraintsImpl;
         {
             TypeIdentifierPair type_ids_max_memory_footprint;
             ReturnCode_t return_code_max_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_uint32_t", type_ids_max_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_memory_footprint)
@@ -2673,44 +2089,34 @@ void register_HWConstraintsImpl_type_identifier(
                         "max_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_memory_footprint = 0x00000000;
             bool common_max_memory_footprint_ec {false};
-            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                member_id_max_memory_footprint,
-                                                                member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                    type_ids_max_memory_footprint,
-                                                                    common_max_memory_footprint_ec))};
+            CommonStructMember common_max_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_memory_footprint, member_flags_max_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_memory_footprint, common_max_memory_footprint_ec))};
             if (!common_max_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_memory_footprint = "max_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_memory_footprint;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_memory_footprint, detail_max_memory_footprint);
+            CompleteMemberDetail detail_max_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_memory_footprint, member_ann_builtin_max_memory_footprint, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_max_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_memory_footprint, detail_max_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_max_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_hardware_required;
             ReturnCode_t return_code_hardware_required {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hardware_required =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
             {
                 return_code_hardware_required =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_hardware_required);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_hardware_required)
@@ -2723,15 +2129,12 @@ void register_HWConstraintsImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_hardware_required))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_hardware_required,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2743,63 +2146,47 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_hardware_required))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hardware_required = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hardware_required = 0x00000001;
             bool common_hardware_required_ec {false};
-            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_hardware_required,
-                                                             member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_hardware_required,
-                                                                 common_hardware_required_ec))};
+            CommonStructMember common_hardware_required {TypeObjectUtils::build_common_struct_member(member_id_hardware_required, member_flags_hardware_required, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hardware_required, common_hardware_required_ec))};
             if (!common_hardware_required_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hardware_required member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hardware_required member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hardware_required = "hardware_required";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hardware_required;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(
-                name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(
-                common_hardware_required, detail_hardware_required);
+            CompleteMemberDetail detail_hardware_required = TypeObjectUtils::build_complete_member_detail(name_hardware_required, member_ann_builtin_hardware_required, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_hardware_required = TypeObjectUtils::build_complete_struct_member(common_hardware_required, detail_hardware_required);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_hardware_required);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -2809,9 +2196,7 @@ void register_HWConstraintsImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -2823,70 +2208,52 @@ void register_HWConstraintsImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000002;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWConstraintsImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000003;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -2900,37 +2267,27 @@ void register_HWConstraintsImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWConstraintsImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWConstraintsImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWConstraintsImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWConstraintsImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
+        CompleteStructType struct_type_HWConstraintsImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWConstraintsImpl, header_HWConstraintsImpl, member_seq_HWConstraintsImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl,
-                type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWConstraintsImpl, type_name_HWConstraintsImpl.to_string(), type_ids_HWConstraintsImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWConstraintsImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_MLModelImpl_type_identifier(
         TypeIdentifierPair& type_ids_MLModelImpl)
@@ -2938,19 +2295,16 @@ void register_MLModelImpl_type_identifier(
 
     ReturnCode_t return_code_MLModelImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_MLModelImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "MLModelImpl", type_ids_MLModelImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_MLModelImpl)
     {
-        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_MLModelImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_MLModelImpl = "MLModelImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_MLModelImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_MLModelImpl;
-        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
+        CompleteTypeDetail detail_MLModelImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_MLModelImpl, ann_custom_MLModelImpl, type_name_MLModelImpl.to_string());
         CompleteStructHeader header_MLModelImpl;
         header_MLModelImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_MLModelImpl);
         CompleteStructMemberSeq member_seq_MLModelImpl;
@@ -2958,8 +2312,7 @@ void register_MLModelImpl_type_identifier(
             TypeIdentifierPair type_ids_model_path;
             ReturnCode_t return_code_model_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_path)
@@ -2972,41 +2325,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_path = 0x00000000;
             bool common_model_path_ec {false};
-            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path,
-                                                          member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_model_path,
-                                                              common_model_path_ec))};
+            CommonStructMember common_model_path {TypeObjectUtils::build_common_struct_member(member_id_model_path, member_flags_model_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_path, common_model_path_ec))};
             if (!common_model_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_path = "model_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path,
-                            member_ann_builtin_model_path,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path,
-                            detail_model_path);
+            CompleteMemberDetail detail_model_path = TypeObjectUtils::build_complete_member_detail(name_model_path, member_ann_builtin_model_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_path = TypeObjectUtils::build_complete_struct_member(common_model_path, detail_model_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_path);
         }
         {
             TypeIdentifierPair type_ids_model;
             ReturnCode_t return_code_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model)
@@ -3019,19 +2363,15 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model = 0x00000001;
             bool common_model_ec {false};
-            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model,
-                                                     member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                         type_ids_model,
-                                                         common_model_ec))};
+            CommonStructMember common_model {TypeObjectUtils::build_common_struct_member(member_id_model, member_flags_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model, common_model_ec))};
             if (!common_model_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model member TypeIdentifier inconsistent.");
@@ -3040,26 +2380,21 @@ void register_MLModelImpl_type_identifier(
             MemberName name_model = "model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model,
-                            member_ann_builtin_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_model =
-                    TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
+            CompleteMemberDetail detail_model = TypeObjectUtils::build_complete_member_detail(name_model, member_ann_builtin_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_model = TypeObjectUtils::build_complete_struct_member(common_model, detail_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model);
         }
         {
             TypeIdentifierPair type_ids_raw_model;
             ReturnCode_t return_code_raw_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_raw_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_raw_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
             {
                 return_code_raw_model =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_raw_model);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_raw_model)
@@ -3069,9 +2404,7 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_raw_model,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3083,55 +2416,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_raw_model))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_raw_model))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_raw_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_raw_model = 0x00000002;
             bool common_raw_model_ec {false};
-            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model,
-                                                         member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                             type_ids_raw_model,
-                                                             common_raw_model_ec))};
+            CommonStructMember common_raw_model {TypeObjectUtils::build_common_struct_member(member_id_raw_model, member_flags_raw_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_raw_model, common_raw_model_ec))};
             if (!common_raw_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure raw_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure raw_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_raw_model = "raw_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_raw_model;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model,
-                            member_ann_builtin_raw_model,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model,
-                            detail_raw_model);
+            CompleteMemberDetail detail_raw_model = TypeObjectUtils::build_complete_member_detail(name_raw_model, member_ann_builtin_raw_model, ann_custom_MLModelImpl);
+            CompleteStructMember member_raw_model = TypeObjectUtils::build_complete_struct_member(common_raw_model, detail_raw_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_raw_model);
         }
         {
             TypeIdentifierPair type_ids_model_properties_path;
             ReturnCode_t return_code_model_properties_path {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties_path =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties_path);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties_path)
@@ -3144,41 +2463,32 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties_path))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties_path = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties_path = 0x00000003;
             bool common_model_properties_path_ec {false};
-            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(
-                                                                 member_id_model_properties_path,
-                                                                 member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                     type_ids_model_properties_path,
-                                                                     common_model_properties_path_ec))};
+            CommonStructMember common_model_properties_path {TypeObjectUtils::build_common_struct_member(member_id_model_properties_path, member_flags_model_properties_path, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties_path, common_model_properties_path_ec))};
             if (!common_model_properties_path_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties_path member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties_path member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties_path = "model_properties_path";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties_path;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties_path, detail_model_properties_path);
+            CompleteMemberDetail detail_model_properties_path = TypeObjectUtils::build_complete_member_detail(name_model_properties_path, member_ann_builtin_model_properties_path, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties_path = TypeObjectUtils::build_complete_struct_member(common_model_properties_path, detail_model_properties_path);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties_path);
         }
         {
             TypeIdentifierPair type_ids_model_properties;
             ReturnCode_t return_code_model_properties {eprosima::fastdds::dds::RETCODE_OK};
             return_code_model_properties =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_model_properties);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_model_properties)
@@ -3191,47 +2501,38 @@ void register_MLModelImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_model_properties))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_model_properties = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_model_properties = 0x00000004;
             bool common_model_properties_ec {false};
-            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_model_properties,
-                                                                common_model_properties_ec))};
+            CommonStructMember common_model_properties {TypeObjectUtils::build_common_struct_member(member_id_model_properties, member_flags_model_properties, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_model_properties, common_model_properties_ec))};
             if (!common_model_properties_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure model_properties member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure model_properties member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_model_properties = "model_properties";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_model_properties;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(
-                name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
-            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(
-                common_model_properties, detail_model_properties);
+            CompleteMemberDetail detail_model_properties = TypeObjectUtils::build_complete_member_detail(name_model_properties, member_ann_builtin_model_properties, ann_custom_MLModelImpl);
+            CompleteStructMember member_model_properties = TypeObjectUtils::build_complete_struct_member(common_model_properties, detail_model_properties);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_model_properties);
         }
         {
             TypeIdentifierPair type_ids_input_batch;
             ReturnCode_t return_code_input_batch {eprosima::fastdds::dds::RETCODE_OK};
             return_code_input_batch =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
             {
                 return_code_input_batch =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "anonymous_string_unbounded", type_ids_input_batch);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_input_batch)
@@ -3244,15 +2545,12 @@ void register_MLModelImpl_type_identifier(
                                 "anonymous_string_unbounded", type_ids_input_batch))
                         {
                             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                    "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                         }
                     }
                 }
                 bool element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new
-                                                                                                            TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                                        type_ids_input_batch,
-                                                                                                                        element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3264,56 +2562,41 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(
-                    equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded,
-                    element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_anonymous_string_unbounded_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_anonymous_string_unbounded_unbounded, element_flags_anonymous_sequence_anonymous_string_unbounded_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_anonymous_string_unbounded_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_anonymous_string_unbounded_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_anonymous_string_unbounded_unbounded", type_ids_input_batch))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_anonymous_string_unbounded_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_input_batch = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_input_batch = 0x00000005;
             bool common_input_batch_ec {false};
-            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch,
-                                                           member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                               type_ids_input_batch,
-                                                               common_input_batch_ec))};
+            CommonStructMember common_input_batch {TypeObjectUtils::build_common_struct_member(member_id_input_batch, member_flags_input_batch, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_input_batch, common_input_batch_ec))};
             if (!common_input_batch_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure input_batch member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure input_batch member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_input_batch = "input_batch";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_input_batch;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch,
-                            member_ann_builtin_input_batch,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch,
-                            detail_input_batch);
+            CompleteMemberDetail detail_input_batch = TypeObjectUtils::build_complete_member_detail(name_input_batch, member_ann_builtin_input_batch, ann_custom_MLModelImpl);
+            CompleteStructMember member_input_batch = TypeObjectUtils::build_complete_struct_member(common_input_batch, detail_input_batch);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_input_batch);
         }
         {
             TypeIdentifierPair type_ids_target_latency;
             ReturnCode_t return_code_target_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_target_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_target_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_target_latency)
@@ -3322,43 +2605,34 @@ void register_MLModelImpl_type_identifier(
                         "target_latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_target_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_target_latency = 0x00000006;
             bool common_target_latency_ec {false};
-            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_target_latency,
-                                                              common_target_latency_ec))};
+            CommonStructMember common_target_latency {TypeObjectUtils::build_common_struct_member(member_id_target_latency, member_flags_target_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_target_latency, common_target_latency_ec))};
             if (!common_target_latency_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure target_latency member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure target_latency member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_target_latency = "target_latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_target_latency;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(
-                name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
-            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(
-                common_target_latency, detail_target_latency);
+            CompleteMemberDetail detail_target_latency = TypeObjectUtils::build_complete_member_detail(name_target_latency, member_ann_builtin_target_latency, ann_custom_MLModelImpl);
+            CompleteStructMember member_target_latency = TypeObjectUtils::build_complete_struct_member(common_target_latency, detail_target_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_target_latency);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3368,9 +2642,7 @@ void register_MLModelImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3382,70 +2654,52 @@ void register_MLModelImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000007;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_MLModelImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_MLModelImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000008;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3459,37 +2713,27 @@ void register_MLModelImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_MLModelImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_MLModelImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_MLModelImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_MLModelImpl, member_task_id);
         }
-        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
+        CompleteStructType struct_type_MLModelImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_MLModelImpl, header_MLModelImpl, member_seq_MLModelImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl,
-                type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_MLModelImpl, type_name_MLModelImpl.to_string(), type_ids_MLModelImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "MLModelImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_HWResourceImpl_type_identifier(
         TypeIdentifierPair& type_ids_HWResourceImpl)
@@ -3497,19 +2741,16 @@ void register_HWResourceImpl_type_identifier(
 
     ReturnCode_t return_code_HWResourceImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_HWResourceImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "HWResourceImpl", type_ids_HWResourceImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_HWResourceImpl)
     {
-        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_HWResourceImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_HWResourceImpl = "HWResourceImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_HWResourceImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_HWResourceImpl;
-        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
+        CompleteTypeDetail detail_HWResourceImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_HWResourceImpl, ann_custom_HWResourceImpl, type_name_HWResourceImpl.to_string());
         CompleteStructHeader header_HWResourceImpl;
         header_HWResourceImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_HWResourceImpl);
         CompleteStructMemberSeq member_seq_HWResourceImpl;
@@ -3517,8 +2758,7 @@ void register_HWResourceImpl_type_identifier(
             TypeIdentifierPair type_ids_hw_description;
             ReturnCode_t return_code_hw_description {eprosima::fastdds::dds::RETCODE_OK};
             return_code_hw_description =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_string_unbounded", type_ids_hw_description);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_hw_description)
@@ -3531,40 +2771,32 @@ void register_HWResourceImpl_type_identifier(
                             "anonymous_string_unbounded", type_ids_hw_description))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_hw_description = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_hw_description = 0x00000000;
             bool common_hw_description_ec {false};
-            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(
-                                                          member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_hw_description,
-                                                              common_hw_description_ec))};
+            CommonStructMember common_hw_description {TypeObjectUtils::build_common_struct_member(member_id_hw_description, member_flags_hw_description, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_hw_description, common_hw_description_ec))};
             if (!common_hw_description_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure hw_description member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure hw_description member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_hw_description = "hw_description";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_hw_description;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(
-                name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
-            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(
-                common_hw_description, detail_hw_description);
+            CompleteMemberDetail detail_hw_description = TypeObjectUtils::build_complete_member_detail(name_hw_description, member_ann_builtin_hw_description, ann_custom_HWResourceImpl);
+            CompleteStructMember member_hw_description = TypeObjectUtils::build_complete_struct_member(common_hw_description, detail_hw_description);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_hw_description);
         }
         {
             TypeIdentifierPair type_ids_power_consumption;
             ReturnCode_t return_code_power_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_power_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_power_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_power_consumption)
@@ -3573,37 +2805,28 @@ void register_HWResourceImpl_type_identifier(
                         "power_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_power_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_power_consumption = 0x00000001;
             bool common_power_consumption_ec {false};
-            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(
-                                                             member_id_power_consumption,
-                                                             member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                 type_ids_power_consumption,
-                                                                 common_power_consumption_ec))};
+            CommonStructMember common_power_consumption {TypeObjectUtils::build_common_struct_member(member_id_power_consumption, member_flags_power_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_power_consumption, common_power_consumption_ec))};
             if (!common_power_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure power_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure power_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_power_consumption = "power_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_power_consumption;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
-            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_power_consumption, detail_power_consumption);
+            CompleteMemberDetail detail_power_consumption = TypeObjectUtils::build_complete_member_detail(name_power_consumption, member_ann_builtin_power_consumption, ann_custom_HWResourceImpl);
+            CompleteStructMember member_power_consumption = TypeObjectUtils::build_complete_struct_member(common_power_consumption, detail_power_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_power_consumption);
         }
         {
             TypeIdentifierPair type_ids_latency;
             ReturnCode_t return_code_latency {eprosima::fastdds::dds::RETCODE_OK};
             return_code_latency =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_latency);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_latency)
@@ -3612,15 +2835,11 @@ void register_HWResourceImpl_type_identifier(
                         "latency Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_latency = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_latency = 0x00000002;
             bool common_latency_ec {false};
-            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency,
-                                                       member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_latency,
-                                                           common_latency_ec))};
+            CommonStructMember common_latency {TypeObjectUtils::build_common_struct_member(member_id_latency, member_flags_latency, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_latency, common_latency_ec))};
             if (!common_latency_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure latency member TypeIdentifier inconsistent.");
@@ -3629,19 +2848,15 @@ void register_HWResourceImpl_type_identifier(
             MemberName name_latency = "latency";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_latency;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency,
-                            member_ann_builtin_latency,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency,
-                            detail_latency);
+            CompleteMemberDetail detail_latency = TypeObjectUtils::build_complete_member_detail(name_latency, member_ann_builtin_latency, ann_custom_HWResourceImpl);
+            CompleteStructMember member_latency = TypeObjectUtils::build_complete_struct_member(common_latency, detail_latency);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_latency);
         }
         {
             TypeIdentifierPair type_ids_memory_footprint_of_ml_model;
             ReturnCode_t return_code_memory_footprint_of_ml_model {eprosima::fastdds::dds::RETCODE_OK};
             return_code_memory_footprint_of_ml_model =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_memory_footprint_of_ml_model);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_memory_footprint_of_ml_model)
@@ -3650,38 +2865,28 @@ void register_HWResourceImpl_type_identifier(
                         "memory_footprint_of_ml_model Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_memory_footprint_of_ml_model = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_memory_footprint_of_ml_model = 0x00000003;
             bool common_memory_footprint_of_ml_model_ec {false};
-            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(
-                                                                        member_id_memory_footprint_of_ml_model,
-                                                                        member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                            type_ids_memory_footprint_of_ml_model,
-                                                                            common_memory_footprint_of_ml_model_ec))};
+            CommonStructMember common_memory_footprint_of_ml_model {TypeObjectUtils::build_common_struct_member(member_id_memory_footprint_of_ml_model, member_flags_memory_footprint_of_ml_model, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_memory_footprint_of_ml_model, common_memory_footprint_of_ml_model_ec))};
             if (!common_memory_footprint_of_ml_model_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure memory_footprint_of_ml_model member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_memory_footprint_of_ml_model = "memory_footprint_of_ml_model";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_memory_footprint_of_ml_model;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(
-                name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(
-                common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
+            CompleteMemberDetail detail_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_member_detail(name_memory_footprint_of_ml_model, member_ann_builtin_memory_footprint_of_ml_model, ann_custom_HWResourceImpl);
+            CompleteStructMember member_memory_footprint_of_ml_model = TypeObjectUtils::build_complete_struct_member(common_memory_footprint_of_ml_model, detail_memory_footprint_of_ml_model);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_memory_footprint_of_ml_model);
         }
         {
             TypeIdentifierPair type_ids_max_hw_memory_footprint;
             ReturnCode_t return_code_max_hw_memory_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_max_hw_memory_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_max_hw_memory_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_max_hw_memory_footprint)
@@ -3690,45 +2895,34 @@ void register_HWResourceImpl_type_identifier(
                         "max_hw_memory_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_max_hw_memory_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_max_hw_memory_footprint = 0x00000004;
             bool common_max_hw_memory_footprint_ec {false};
-            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(
-                                                                   member_id_max_hw_memory_footprint,
-                                                                   member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                       type_ids_max_hw_memory_footprint,
-                                                                       common_max_hw_memory_footprint_ec))};
+            CommonStructMember common_max_hw_memory_footprint {TypeObjectUtils::build_common_struct_member(member_id_max_hw_memory_footprint, member_flags_max_hw_memory_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_max_hw_memory_footprint, common_max_hw_memory_footprint_ec))};
             if (!common_max_hw_memory_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure max_hw_memory_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_max_hw_memory_footprint = "max_hw_memory_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_max_hw_memory_footprint;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint,
-                ann_custom_HWResourceImpl);
-            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
+            CompleteMemberDetail detail_max_hw_memory_footprint = TypeObjectUtils::build_complete_member_detail(name_max_hw_memory_footprint, member_ann_builtin_max_hw_memory_footprint, ann_custom_HWResourceImpl);
+            CompleteStructMember member_max_hw_memory_footprint = TypeObjectUtils::build_complete_struct_member(common_max_hw_memory_footprint, detail_max_hw_memory_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_max_hw_memory_footprint);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -3738,9 +2932,7 @@ void register_HWResourceImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -3752,70 +2944,52 @@ void register_HWResourceImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000005;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_HWResourceImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_HWResourceImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000006;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -3829,37 +3003,27 @@ void register_HWResourceImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_HWResourceImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_HWResourceImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_HWResourceImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_HWResourceImpl, member_task_id);
         }
-        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
+        CompleteStructType struct_type_HWResourceImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_HWResourceImpl, header_HWResourceImpl, member_seq_HWResourceImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl,
-                type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_HWResourceImpl, type_name_HWResourceImpl.to_string(), type_ids_HWResourceImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "HWResourceImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
-
 // TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
 void register_CO2FootprintImpl_type_identifier(
         TypeIdentifierPair& type_ids_CO2FootprintImpl)
@@ -3867,29 +3031,24 @@ void register_CO2FootprintImpl_type_identifier(
 
     ReturnCode_t return_code_CO2FootprintImpl {eprosima::fastdds::dds::RETCODE_OK};
     return_code_CO2FootprintImpl =
-            eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                    get_type_identifiers(
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
         "CO2FootprintImpl", type_ids_CO2FootprintImpl);
     if (eprosima::fastdds::dds::RETCODE_OK != return_code_CO2FootprintImpl)
     {
-        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(
-            eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
-            false, false);
+        StructTypeFlag struct_flags_CO2FootprintImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
         QualifiedTypeName type_name_CO2FootprintImpl = "CO2FootprintImpl";
         eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_CO2FootprintImpl;
         eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_CO2FootprintImpl;
-        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(
-            type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
+        CompleteTypeDetail detail_CO2FootprintImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_CO2FootprintImpl, ann_custom_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string());
         CompleteStructHeader header_CO2FootprintImpl;
-        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(
-            TypeIdentifier(), detail_CO2FootprintImpl);
+        header_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_CO2FootprintImpl);
         CompleteStructMemberSeq member_seq_CO2FootprintImpl;
         {
             TypeIdentifierPair type_ids_carbon_footprint;
             ReturnCode_t return_code_carbon_footprint {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_footprint =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_footprint);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_footprint)
@@ -3898,36 +3057,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_footprint Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_footprint = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_footprint = 0x00000000;
             bool common_carbon_footprint_ec {false};
-            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_footprint,
-                                                                common_carbon_footprint_ec))};
+            CommonStructMember common_carbon_footprint {TypeObjectUtils::build_common_struct_member(member_id_carbon_footprint, member_flags_carbon_footprint, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_footprint, common_carbon_footprint_ec))};
             if (!common_carbon_footprint_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_footprint member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_footprint member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_footprint = "carbon_footprint";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_footprint;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_footprint, detail_carbon_footprint);
+            CompleteMemberDetail detail_carbon_footprint = TypeObjectUtils::build_complete_member_detail(name_carbon_footprint, member_ann_builtin_carbon_footprint, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_footprint = TypeObjectUtils::build_complete_struct_member(common_carbon_footprint, detail_carbon_footprint);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_footprint);
         }
         {
             TypeIdentifierPair type_ids_energy_consumption;
             ReturnCode_t return_code_energy_consumption {eprosima::fastdds::dds::RETCODE_OK};
             return_code_energy_consumption =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_energy_consumption);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_energy_consumption)
@@ -3936,37 +3087,28 @@ void register_CO2FootprintImpl_type_identifier(
                         "energy_consumption Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_energy_consumption = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_energy_consumption = 0x00000001;
             bool common_energy_consumption_ec {false};
-            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(
-                                                              member_id_energy_consumption,
-                                                              member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                  type_ids_energy_consumption,
-                                                                  common_energy_consumption_ec))};
+            CommonStructMember common_energy_consumption {TypeObjectUtils::build_common_struct_member(member_id_energy_consumption, member_flags_energy_consumption, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_energy_consumption, common_energy_consumption_ec))};
             if (!common_energy_consumption_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure energy_consumption member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure energy_consumption member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_energy_consumption = "energy_consumption";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_energy_consumption;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(
-                name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(
-                common_energy_consumption, detail_energy_consumption);
+            CompleteMemberDetail detail_energy_consumption = TypeObjectUtils::build_complete_member_detail(name_energy_consumption, member_ann_builtin_energy_consumption, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_energy_consumption = TypeObjectUtils::build_complete_struct_member(common_energy_consumption, detail_energy_consumption);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_energy_consumption);
         }
         {
             TypeIdentifierPair type_ids_carbon_intensity;
             ReturnCode_t return_code_carbon_intensity {eprosima::fastdds::dds::RETCODE_OK};
             return_code_carbon_intensity =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "_double", type_ids_carbon_intensity);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_carbon_intensity)
@@ -3975,43 +3117,34 @@ void register_CO2FootprintImpl_type_identifier(
                         "carbon_intensity Structure member TypeIdentifier unknown to TypeObjectRegistry.");
                 return;
             }
-            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_carbon_intensity = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_carbon_intensity = 0x00000002;
             bool common_carbon_intensity_ec {false};
-            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(
-                                                            member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                type_ids_carbon_intensity,
-                                                                common_carbon_intensity_ec))};
+            CommonStructMember common_carbon_intensity {TypeObjectUtils::build_common_struct_member(member_id_carbon_intensity, member_flags_carbon_intensity, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_carbon_intensity, common_carbon_intensity_ec))};
             if (!common_carbon_intensity_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure carbon_intensity member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure carbon_intensity member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_carbon_intensity = "carbon_intensity";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_carbon_intensity;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(
-                name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(
-                common_carbon_intensity, detail_carbon_intensity);
+            CompleteMemberDetail detail_carbon_intensity = TypeObjectUtils::build_complete_member_detail(name_carbon_intensity, member_ann_builtin_carbon_intensity, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_carbon_intensity = TypeObjectUtils::build_complete_struct_member(common_carbon_intensity, detail_carbon_intensity);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_carbon_intensity);
         }
         {
             TypeIdentifierPair type_ids_extra_data;
             ReturnCode_t return_code_extra_data {eprosima::fastdds::dds::RETCODE_OK};
             return_code_extra_data =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "anonymous_sequence_byte_unbounded", type_ids_extra_data);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
             {
                 return_code_extra_data =
-                        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                                get_type_identifiers(
+                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                     "_byte", type_ids_extra_data);
 
                 if (eprosima::fastdds::dds::RETCODE_OK != return_code_extra_data)
@@ -4021,9 +3154,7 @@ void register_CO2FootprintImpl_type_identifier(
                     return;
                 }
                 bool element_identifier_anonymous_sequence_byte_unbounded_ec {false};
-                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(
-                                                                                                  type_ids_extra_data,
-                                                                                                  element_identifier_anonymous_sequence_byte_unbounded_ec))};
+                TypeIdentifier* element_identifier_anonymous_sequence_byte_unbounded {new TypeIdentifier(TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, element_identifier_anonymous_sequence_byte_unbounded_ec))};
                 if (!element_identifier_anonymous_sequence_byte_unbounded_ec)
                 {
                     EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Sequence element TypeIdentifier inconsistent.");
@@ -4035,70 +3166,52 @@ void register_CO2FootprintImpl_type_identifier(
                     equiv_kind_anonymous_sequence_byte_unbounded = EK_BOTH;
                 }
                 CollectionElementFlag element_flags_anonymous_sequence_byte_unbounded = 0;
-                PlainCollectionHeader header_anonymous_sequence_byte_unbounded =
-                        TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded,
-                                element_flags_anonymous_sequence_byte_unbounded);
+                PlainCollectionHeader header_anonymous_sequence_byte_unbounded = TypeObjectUtils::build_plain_collection_header(equiv_kind_anonymous_sequence_byte_unbounded, element_flags_anonymous_sequence_byte_unbounded);
                 {
                     SBound bound = 0;
-                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(
-                        header_anonymous_sequence_byte_unbounded, bound,
-                        eprosima::fastcdr::external<TypeIdentifier>(
-                            element_identifier_anonymous_sequence_byte_unbounded));
+                    PlainSequenceSElemDefn seq_sdefn = TypeObjectUtils::build_plain_sequence_s_elem_defn(header_anonymous_sequence_byte_unbounded, bound,
+                                eprosima::fastcdr::external<TypeIdentifier>(element_identifier_anonymous_sequence_byte_unbounded));
                     if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn,
-                            "anonymous_sequence_byte_unbounded", type_ids_extra_data))
+                            TypeObjectUtils::build_and_register_s_sequence_type_identifier(seq_sdefn, "anonymous_sequence_byte_unbounded", type_ids_extra_data))
                     {
                         EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                                "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
+                            "anonymous_sequence_byte_unbounded already registered in TypeObjectRegistry for a different type.");
                     }
                 }
             }
-            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, false, false);
+            StructMemberFlag member_flags_extra_data = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
             MemberId member_id_extra_data = 0x00000003;
             bool common_extra_data_ec {false};
-            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data,
-                                                          member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                              type_ids_extra_data,
-                                                              common_extra_data_ec))};
+            CommonStructMember common_extra_data {TypeObjectUtils::build_common_struct_member(member_id_extra_data, member_flags_extra_data, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_extra_data, common_extra_data_ec))};
             if (!common_extra_data_ec)
             {
-                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
-                        "Structure extra_data member TypeIdentifier inconsistent.");
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure extra_data member TypeIdentifier inconsistent.");
                 return;
             }
             MemberName name_extra_data = "extra_data";
             eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_extra_data;
             ann_custom_CO2FootprintImpl.reset();
-            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data,
-                            member_ann_builtin_extra_data,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data,
-                            detail_extra_data);
+            CompleteMemberDetail detail_extra_data = TypeObjectUtils::build_complete_member_detail(name_extra_data, member_ann_builtin_extra_data, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_extra_data = TypeObjectUtils::build_complete_struct_member(common_extra_data, detail_extra_data);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_extra_data);
         }
         {
             TypeIdentifierPair type_ids_task_id;
             ReturnCode_t return_code_task_id {eprosima::fastdds::dds::RETCODE_OK};
             return_code_task_id =
-                    eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().
-                            get_type_identifiers(
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
                 "TaskIdImpl", type_ids_task_id);
 
             if (eprosima::fastdds::dds::RETCODE_OK != return_code_task_id)
             {
-                ::register_TaskIdImpl_type_identifier(type_ids_task_id);
+            ::register_TaskIdImpl_type_identifier(type_ids_task_id);
             }
-            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(
-                eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
-                false, false, true, false);
+            StructMemberFlag member_flags_task_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
             MemberId member_id_task_id = 0x00000004;
             bool common_task_id_ec {false};
-            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id,
-                                                       member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(
-                                                           type_ids_task_id,
-                                                           common_task_id_ec))};
+            CommonStructMember common_task_id {TypeObjectUtils::build_common_struct_member(member_id_task_id, member_flags_task_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_task_id, common_task_id_ec))};
             if (!common_task_id_ec)
             {
                 EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure task_id member TypeIdentifier inconsistent.");
@@ -4112,33 +3225,389 @@ void register_CO2FootprintImpl_type_identifier(
             eprosima::fastcdr::optional<AnnotationParameterValue> min_task_id;
             eprosima::fastcdr::optional<AnnotationParameterValue> max_task_id;
             eprosima::fastcdr::optional<std::string> hash_id_task_id;
-            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() ||
-                    hash_id_task_id.has_value())
+            if (unit_task_id.has_value() || min_task_id.has_value() || max_task_id.has_value() || hash_id_task_id.has_value())
             {
-                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id,
-                                min_task_id,
-                                max_task_id,
-                                hash_id_task_id);
+                member_ann_builtin_task_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_task_id, min_task_id, max_task_id, hash_id_task_id);
             }
             if (!tmp_ann_custom_task_id.empty())
             {
                 ann_custom_CO2FootprintImpl = tmp_ann_custom_task_id;
             }
-            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id,
-                            member_ann_builtin_task_id,
-                            ann_custom_CO2FootprintImpl);
-            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id,
-                            detail_task_id);
+            CompleteMemberDetail detail_task_id = TypeObjectUtils::build_complete_member_detail(name_task_id, member_ann_builtin_task_id, ann_custom_CO2FootprintImpl);
+            CompleteStructMember member_task_id = TypeObjectUtils::build_complete_struct_member(common_task_id, detail_task_id);
             TypeObjectUtils::add_complete_struct_member(member_seq_CO2FootprintImpl, member_task_id);
         }
-        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(
-            struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
+        CompleteStructType struct_type_CO2FootprintImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_CO2FootprintImpl, header_CO2FootprintImpl, member_seq_CO2FootprintImpl);
         if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
-                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl,
-                type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_CO2FootprintImpl, type_name_CO2FootprintImpl.to_string(), type_ids_CO2FootprintImpl))
         {
             EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
                     "CO2FootprintImpl already registered in TypeObjectRegistry for a different type.");
         }
     }
 }
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_RequestTypeImpl_type_identifier(
+        TypeIdentifierPair& type_ids_RequestTypeImpl)
+{
+
+    ReturnCode_t return_code_RequestTypeImpl {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_RequestTypeImpl =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "RequestTypeImpl", type_ids_RequestTypeImpl);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_RequestTypeImpl)
+    {
+        StructTypeFlag struct_flags_RequestTypeImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_RequestTypeImpl = "RequestTypeImpl";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_RequestTypeImpl;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_RequestTypeImpl;
+        CompleteTypeDetail detail_RequestTypeImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_RequestTypeImpl, ann_custom_RequestTypeImpl, type_name_RequestTypeImpl.to_string());
+        CompleteStructHeader header_RequestTypeImpl;
+        header_RequestTypeImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_RequestTypeImpl);
+        CompleteStructMemberSeq member_seq_RequestTypeImpl;
+        {
+            TypeIdentifierPair type_ids_node_id;
+            ReturnCode_t return_code_node_id {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_node_id =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_node_id);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_id)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "node_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_node_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_node_id = 0x00000000;
+            bool common_node_id_ec {false};
+            CommonStructMember common_node_id {TypeObjectUtils::build_common_struct_member(member_id_node_id, member_flags_node_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_id, common_node_id_ec))};
+            if (!common_node_id_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_id member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_node_id = "node_id";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_id;
+            ann_custom_RequestTypeImpl.reset();
+            AppliedAnnotationSeq tmp_ann_custom_node_id;
+            eprosima::fastcdr::optional<std::string> unit_node_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_node_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_node_id;
+            eprosima::fastcdr::optional<std::string> hash_id_node_id;
+            if (unit_node_id.has_value() || min_node_id.has_value() || max_node_id.has_value() || hash_id_node_id.has_value())
+            {
+                member_ann_builtin_node_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_id, min_node_id, max_node_id, hash_id_node_id);
+            }
+            if (!tmp_ann_custom_node_id.empty())
+            {
+                ann_custom_RequestTypeImpl = tmp_ann_custom_node_id;
+            }
+            CompleteMemberDetail detail_node_id = TypeObjectUtils::build_complete_member_detail(name_node_id, member_ann_builtin_node_id, ann_custom_RequestTypeImpl);
+            CompleteStructMember member_node_id = TypeObjectUtils::build_complete_struct_member(common_node_id, detail_node_id);
+            TypeObjectUtils::add_complete_struct_member(member_seq_RequestTypeImpl, member_node_id);
+        }
+        {
+            TypeIdentifierPair type_ids_transaction_id;
+            ReturnCode_t return_code_transaction_id {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_transaction_id =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_transaction_id);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_transaction_id)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "transaction_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_transaction_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_transaction_id = 0x00000001;
+            bool common_transaction_id_ec {false};
+            CommonStructMember common_transaction_id {TypeObjectUtils::build_common_struct_member(member_id_transaction_id, member_flags_transaction_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_transaction_id, common_transaction_id_ec))};
+            if (!common_transaction_id_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure transaction_id member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_transaction_id = "transaction_id";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_transaction_id;
+            ann_custom_RequestTypeImpl.reset();
+            AppliedAnnotationSeq tmp_ann_custom_transaction_id;
+            eprosima::fastcdr::optional<std::string> unit_transaction_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_transaction_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_transaction_id;
+            eprosima::fastcdr::optional<std::string> hash_id_transaction_id;
+            if (unit_transaction_id.has_value() || min_transaction_id.has_value() || max_transaction_id.has_value() || hash_id_transaction_id.has_value())
+            {
+                member_ann_builtin_transaction_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_transaction_id, min_transaction_id, max_transaction_id, hash_id_transaction_id);
+            }
+            if (!tmp_ann_custom_transaction_id.empty())
+            {
+                ann_custom_RequestTypeImpl = tmp_ann_custom_transaction_id;
+            }
+            CompleteMemberDetail detail_transaction_id = TypeObjectUtils::build_complete_member_detail(name_transaction_id, member_ann_builtin_transaction_id, ann_custom_RequestTypeImpl);
+            CompleteStructMember member_transaction_id = TypeObjectUtils::build_complete_struct_member(common_transaction_id, detail_transaction_id);
+            TypeObjectUtils::add_complete_struct_member(member_seq_RequestTypeImpl, member_transaction_id);
+        }
+        {
+            TypeIdentifierPair type_ids_configuration;
+            ReturnCode_t return_code_configuration {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_configuration =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_string_unbounded", type_ids_configuration);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_configuration)
+            {
+                {
+                    SBound bound = 0;
+                    StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                            "anonymous_string_unbounded", type_ids_configuration))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_configuration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_configuration = 0x00000002;
+            bool common_configuration_ec {false};
+            CommonStructMember common_configuration {TypeObjectUtils::build_common_struct_member(member_id_configuration, member_flags_configuration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_configuration, common_configuration_ec))};
+            if (!common_configuration_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure configuration member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_configuration = "configuration";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_configuration;
+            ann_custom_RequestTypeImpl.reset();
+            CompleteMemberDetail detail_configuration = TypeObjectUtils::build_complete_member_detail(name_configuration, member_ann_builtin_configuration, ann_custom_RequestTypeImpl);
+            CompleteStructMember member_configuration = TypeObjectUtils::build_complete_struct_member(common_configuration, detail_configuration);
+            TypeObjectUtils::add_complete_struct_member(member_seq_RequestTypeImpl, member_configuration);
+        }
+        CompleteStructType struct_type_RequestTypeImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_RequestTypeImpl, header_RequestTypeImpl, member_seq_RequestTypeImpl);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_RequestTypeImpl, type_name_RequestTypeImpl.to_string(), type_ids_RequestTypeImpl))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "RequestTypeImpl already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+// TypeIdentifier is returned by reference: dependent structures/unions are registered in this same method
+void register_ResponseTypeImpl_type_identifier(
+        TypeIdentifierPair& type_ids_ResponseTypeImpl)
+{
+
+    ReturnCode_t return_code_ResponseTypeImpl {eprosima::fastdds::dds::RETCODE_OK};
+    return_code_ResponseTypeImpl =
+        eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+        "ResponseTypeImpl", type_ids_ResponseTypeImpl);
+    if (eprosima::fastdds::dds::RETCODE_OK != return_code_ResponseTypeImpl)
+    {
+        StructTypeFlag struct_flags_ResponseTypeImpl = TypeObjectUtils::build_struct_type_flag(eprosima::fastdds::dds::xtypes::ExtensibilityKind::APPENDABLE,
+                false, false);
+        QualifiedTypeName type_name_ResponseTypeImpl = "ResponseTypeImpl";
+        eprosima::fastcdr::optional<AppliedBuiltinTypeAnnotations> type_ann_builtin_ResponseTypeImpl;
+        eprosima::fastcdr::optional<AppliedAnnotationSeq> ann_custom_ResponseTypeImpl;
+        CompleteTypeDetail detail_ResponseTypeImpl = TypeObjectUtils::build_complete_type_detail(type_ann_builtin_ResponseTypeImpl, ann_custom_ResponseTypeImpl, type_name_ResponseTypeImpl.to_string());
+        CompleteStructHeader header_ResponseTypeImpl;
+        header_ResponseTypeImpl = TypeObjectUtils::build_complete_struct_header(TypeIdentifier(), detail_ResponseTypeImpl);
+        CompleteStructMemberSeq member_seq_ResponseTypeImpl;
+        {
+            TypeIdentifierPair type_ids_node_id;
+            ReturnCode_t return_code_node_id {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_node_id =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_node_id);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_node_id)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "node_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_node_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_node_id = 0x00000000;
+            bool common_node_id_ec {false};
+            CommonStructMember common_node_id {TypeObjectUtils::build_common_struct_member(member_id_node_id, member_flags_node_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_node_id, common_node_id_ec))};
+            if (!common_node_id_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure node_id member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_node_id = "node_id";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_node_id;
+            ann_custom_ResponseTypeImpl.reset();
+            AppliedAnnotationSeq tmp_ann_custom_node_id;
+            eprosima::fastcdr::optional<std::string> unit_node_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_node_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_node_id;
+            eprosima::fastcdr::optional<std::string> hash_id_node_id;
+            if (unit_node_id.has_value() || min_node_id.has_value() || max_node_id.has_value() || hash_id_node_id.has_value())
+            {
+                member_ann_builtin_node_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_node_id, min_node_id, max_node_id, hash_id_node_id);
+            }
+            if (!tmp_ann_custom_node_id.empty())
+            {
+                ann_custom_ResponseTypeImpl = tmp_ann_custom_node_id;
+            }
+            CompleteMemberDetail detail_node_id = TypeObjectUtils::build_complete_member_detail(name_node_id, member_ann_builtin_node_id, ann_custom_ResponseTypeImpl);
+            CompleteStructMember member_node_id = TypeObjectUtils::build_complete_struct_member(common_node_id, detail_node_id);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ResponseTypeImpl, member_node_id);
+        }
+        {
+            TypeIdentifierPair type_ids_transaction_id;
+            ReturnCode_t return_code_transaction_id {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_transaction_id =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_int32_t", type_ids_transaction_id);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_transaction_id)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "transaction_id Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_transaction_id = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, true, false);
+            MemberId member_id_transaction_id = 0x00000001;
+            bool common_transaction_id_ec {false};
+            CommonStructMember common_transaction_id {TypeObjectUtils::build_common_struct_member(member_id_transaction_id, member_flags_transaction_id, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_transaction_id, common_transaction_id_ec))};
+            if (!common_transaction_id_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure transaction_id member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_transaction_id = "transaction_id";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_transaction_id;
+            ann_custom_ResponseTypeImpl.reset();
+            AppliedAnnotationSeq tmp_ann_custom_transaction_id;
+            eprosima::fastcdr::optional<std::string> unit_transaction_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> min_transaction_id;
+            eprosima::fastcdr::optional<AnnotationParameterValue> max_transaction_id;
+            eprosima::fastcdr::optional<std::string> hash_id_transaction_id;
+            if (unit_transaction_id.has_value() || min_transaction_id.has_value() || max_transaction_id.has_value() || hash_id_transaction_id.has_value())
+            {
+                member_ann_builtin_transaction_id = TypeObjectUtils::build_applied_builtin_member_annotations(unit_transaction_id, min_transaction_id, max_transaction_id, hash_id_transaction_id);
+            }
+            if (!tmp_ann_custom_transaction_id.empty())
+            {
+                ann_custom_ResponseTypeImpl = tmp_ann_custom_transaction_id;
+            }
+            CompleteMemberDetail detail_transaction_id = TypeObjectUtils::build_complete_member_detail(name_transaction_id, member_ann_builtin_transaction_id, ann_custom_ResponseTypeImpl);
+            CompleteStructMember member_transaction_id = TypeObjectUtils::build_complete_struct_member(common_transaction_id, detail_transaction_id);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ResponseTypeImpl, member_transaction_id);
+        }
+        {
+            TypeIdentifierPair type_ids_success;
+            ReturnCode_t return_code_success {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_success =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "_bool", type_ids_success);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_success)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                        "success Structure member TypeIdentifier unknown to TypeObjectRegistry.");
+                return;
+            }
+            StructMemberFlag member_flags_success = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_success = 0x00000002;
+            bool common_success_ec {false};
+            CommonStructMember common_success {TypeObjectUtils::build_common_struct_member(member_id_success, member_flags_success, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_success, common_success_ec))};
+            if (!common_success_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure success member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_success = "success";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_success;
+            ann_custom_ResponseTypeImpl.reset();
+            CompleteMemberDetail detail_success = TypeObjectUtils::build_complete_member_detail(name_success, member_ann_builtin_success, ann_custom_ResponseTypeImpl);
+            CompleteStructMember member_success = TypeObjectUtils::build_complete_struct_member(common_success, detail_success);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ResponseTypeImpl, member_success);
+        }
+        {
+            TypeIdentifierPair type_ids_err_code;
+            ReturnCode_t return_code_err_code {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_err_code =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "ErrorCode", type_ids_err_code);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_err_code)
+            {
+            ::register_ErrorCode_type_identifier(type_ids_err_code);
+            }
+            StructMemberFlag member_flags_err_code = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_err_code = 0x00000003;
+            bool common_err_code_ec {false};
+            CommonStructMember common_err_code {TypeObjectUtils::build_common_struct_member(member_id_err_code, member_flags_err_code, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_err_code, common_err_code_ec))};
+            if (!common_err_code_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure err_code member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_err_code = "err_code";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_err_code;
+            ann_custom_ResponseTypeImpl.reset();
+            CompleteMemberDetail detail_err_code = TypeObjectUtils::build_complete_member_detail(name_err_code, member_ann_builtin_err_code, ann_custom_ResponseTypeImpl);
+            CompleteStructMember member_err_code = TypeObjectUtils::build_complete_struct_member(common_err_code, detail_err_code);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ResponseTypeImpl, member_err_code);
+        }
+        {
+            TypeIdentifierPair type_ids_configuration;
+            ReturnCode_t return_code_configuration {eprosima::fastdds::dds::RETCODE_OK};
+            return_code_configuration =
+                eprosima::fastdds::dds::DomainParticipantFactory::get_instance()->type_object_registry().get_type_identifiers(
+                "anonymous_string_unbounded", type_ids_configuration);
+
+            if (eprosima::fastdds::dds::RETCODE_OK != return_code_configuration)
+            {
+                {
+                    SBound bound = 0;
+                    StringSTypeDefn string_sdefn = TypeObjectUtils::build_string_s_type_defn(bound);
+                    if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                            TypeObjectUtils::build_and_register_s_string_type_identifier(string_sdefn,
+                            "anonymous_string_unbounded", type_ids_configuration))
+                    {
+                        EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                            "anonymous_string_unbounded already registered in TypeObjectRegistry for a different type.");
+                    }
+                }
+            }
+            StructMemberFlag member_flags_configuration = TypeObjectUtils::build_struct_member_flag(eprosima::fastdds::dds::xtypes::TryConstructFailAction::DISCARD,
+                    false, false, false, false);
+            MemberId member_id_configuration = 0x00000004;
+            bool common_configuration_ec {false};
+            CommonStructMember common_configuration {TypeObjectUtils::build_common_struct_member(member_id_configuration, member_flags_configuration, TypeObjectUtils::retrieve_complete_type_identifier(type_ids_configuration, common_configuration_ec))};
+            if (!common_configuration_ec)
+            {
+                EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION, "Structure configuration member TypeIdentifier inconsistent.");
+                return;
+            }
+            MemberName name_configuration = "configuration";
+            eprosima::fastcdr::optional<AppliedBuiltinMemberAnnotations> member_ann_builtin_configuration;
+            ann_custom_ResponseTypeImpl.reset();
+            CompleteMemberDetail detail_configuration = TypeObjectUtils::build_complete_member_detail(name_configuration, member_ann_builtin_configuration, ann_custom_ResponseTypeImpl);
+            CompleteStructMember member_configuration = TypeObjectUtils::build_complete_struct_member(common_configuration, detail_configuration);
+            TypeObjectUtils::add_complete_struct_member(member_seq_ResponseTypeImpl, member_configuration);
+        }
+        CompleteStructType struct_type_ResponseTypeImpl = TypeObjectUtils::build_complete_struct_type(struct_flags_ResponseTypeImpl, header_ResponseTypeImpl, member_seq_ResponseTypeImpl);
+        if (eprosima::fastdds::dds::RETCODE_BAD_PARAMETER ==
+                TypeObjectUtils::build_and_register_struct_type_object(struct_type_ResponseTypeImpl, type_name_ResponseTypeImpl.to_string(), type_ids_ResponseTypeImpl))
+        {
+            EPROSIMA_LOG_ERROR(XTYPES_TYPE_REPRESENTATION,
+                    "ResponseTypeImpl already registered in TypeObjectRegistry for a different type.");
+        }
+    }
+}
+

--- a/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.hpp
+++ b/sustainml_cpp/src/cpp/types/typesImplTypeObjectSupport.hpp
@@ -217,6 +217,30 @@ eProsima_user_DllExport void register_HWResourceImpl_type_identifier(
  */
 eProsima_user_DllExport void register_CO2FootprintImpl_type_identifier(
         eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
+ * @brief Register RequestTypeImpl related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_RequestTypeImpl_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
+/**
+ * @brief Register ResponseTypeImpl related TypeIdentifier.
+ *        Fully-descriptive TypeIdentifiers are directly registered.
+ *        Hash TypeIdentifiers require to fill the TypeObject information and hash it, consequently, the TypeObject is
+ *        indirectly registered as well.
+ *
+ * @param[out] TypeIdentifier of the registered type.
+ *             The returned TypeIdentifier corresponds to the complete TypeIdentifier in case of hashed TypeIdentifiers.
+ *             Invalid TypeIdentifier is returned in case of error.
+ */
+eProsima_user_DllExport void register_ResponseTypeImpl_type_identifier(
+        eprosima::fastdds::dds::xtypes::TypeIdentifierPair& type_ids);
 
 
 #endif // DOXYGEN_SHOULD_SKIP_THIS_PUBLIC

--- a/sustainml_cpp/test/blackbox/common/BlackboxTestsOrchestratorNode.cpp
+++ b/sustainml_cpp/test/blackbox/common/BlackboxTestsOrchestratorNode.cpp
@@ -88,6 +88,19 @@ static TestOrchestratorNodeHandle::DataCollection nodes_ready_expected_data =
     {NodeID::ID_HW_CONSTRAINTS, {Status::NODE_IDLE, 0}}
 };
 
+TEST(OrchestratorNode, OrchestratorConfigurationService)
+{
+    std::shared_ptr<TestOrchestratorNodeHandle> tonh = std::make_shared<TestOrchestratorNodeHandle>();
+
+    orchestrator::OrchestratorNode orchestrator(*(tonh.get()));
+
+    types::RequestType req;
+    types::ResponseType res;
+
+    ASSERT_TRUE(orchestrator.configuration_request(req, res));
+    orchestrator.destroy();
+}
+
 TEST(OrchestratorNode, OrchestratorInitializesProperlyWhenNodesAreALive)
 {
     std::shared_ptr<TestOrchestratorNodeHandle> tonh = std::make_shared<TestOrchestratorNodeHandle>();


### PR DESCRIPTION
This PR add a blackbox test for the configuration_request method on the orchestrtor node with the strcuture of RequestType and ResponseType also added to the types.

The test has passed on this state, and was tested also failing in the oposite assert condition. 