### PR TITLE
[23081] Add env variable to change domain id

### DIFF
--- a/sustainml_cpp/src/cpp/common/Common.hpp
+++ b/sustainml_cpp/src/cpp/common/Common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -24,6 +24,7 @@
 
 #include <fastdds/dds/log/Log.hpp>
 
+#include <cstdlib>
 #include <iostream>
 #include <map>
 #include <utility>
@@ -40,6 +41,9 @@ constexpr const char* HW_CONSTRAINTS_NODE = "HW_CONSTRAINTS_NODE";
 constexpr const char* HW_RESOURCES_NODE = "HW_RESOURCES_NODE";
 constexpr const char* ML_MODEL_METADATA_NODE = "ML_MODEL_METADATA_NODE";
 constexpr const char* ML_MODEL_NODE = "ML_MODEL_NODE";
+
+//!Env variables
+static constexpr const char* SUSTAINML_DOMAIN_URI = "SUSTAINML_DOMAIN_ID";
 
 inline NodeID get_node_id_from_name(
         const eprosima::fastcdr::string_255& name)
@@ -148,7 +152,7 @@ inline uint32_t parse_sustainml_env(
         const uint32_t& option)
 {
     uint32_t domain_to_use = option;
-    if (const char* env = std::getenv("SUSTAINML_DOMAIN_ID"))
+    if (const char* env = std::getenv(SUSTAINML_DOMAIN_URI))
     {
         try
         {

--- a/sustainml_cpp/src/cpp/common/Common.hpp
+++ b/sustainml_cpp/src/cpp/common/Common.hpp
@@ -1,4 +1,4 @@
-// Copyright 2023 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+// Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -142,6 +142,25 @@ inline Topics get_topic_from_name(
         }
     }
     return output;
+}
+
+inline uint32_t parse_sustainml_env(
+        const uint32_t& option)
+{
+    uint32_t domain_to_use = option;
+    if (const char* env = std::getenv("SUSTAINML_DOMAIN_ID"))
+    {
+        try
+        {
+            domain_to_use = static_cast<uint32_t>(std::stoul(env));
+        }
+        catch (...)
+        {
+            EPROSIMA_LOG_ERROR(NODE, "Error parsing SUSTAINML_DOMAIN_ID, using default instead");
+            domain_to_use = option;
+        }
+    }
+    return domain_to_use;
 }
 
 /*!

--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -167,7 +167,8 @@ bool NodeImpl::init(
     pqos.properties().properties().emplace_back("fastdds.application.id", "SUSTAINML", true);
     pqos.properties().properties().emplace_back("fastdds.application.metadata", "", true);
 
-    participant_ = dpf->create_participant(opts.domain, pqos);
+    uint32_t domain = common::parse_sustainml_env(opts.domain);
+    participant_ = dpf->create_participant(domain, pqos);
 
     if (participant_ == nullptr)
     {

--- a/sustainml_cpp/src/cpp/core/RequestReplier.cpp
+++ b/sustainml_cpp/src/cpp/core/RequestReplier.cpp
@@ -18,6 +18,8 @@
 
 #include <core/RequestReplier.hpp>
 
+#include <common/Common.hpp>
+
 #include <fastdds/dds/topic/Topic.hpp>
 #include <fastdds/dds/topic/TypeSupport.hpp>
 
@@ -47,7 +49,8 @@ RequestReplier::RequestReplier(
     DomainParticipantQos pqos;
 
     // Create a DomainParticipant
-    participant_ = dpf->create_participant(0, pqos);
+    uint32_t domain = common::parse_sustainml_env(0);
+    participant_ = dpf->create_participant(domain, pqos);
 
     subscriber_ = participant_->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
 

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -193,7 +193,8 @@ bool OrchestratorNode::init()
     dpqos.properties().properties().emplace_back("fastdds.application.metadata", "", true);
 
     //! Initialize entities
-    participant_ = dpf->create_participant(domain_,
+    uint32_t domain = common::parse_sustainml_env(domain_);
+    participant_ = dpf->create_participant(domain,
                     dpqos,
                     participant_listener_.get(),
                     StatusMask::all() >> StatusMask::data_on_readers());


### PR DESCRIPTION
This PR add the environment variable `SUSTAINML_DOMAIN_ID` to vhange the domain_id uses by the participants od the nodes and orchestrator.

Goes after #67  .
