### PR TITLE
Add Ubuntu CI status badge on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 <div class="badges" align="center">
     <a href="https://opensource.org/licenses/Apache-2.0"><img alt="License Robotics" src="https://img.shields.io/github/license/eProsima/SustainML.svg"/></a>
     <a href="https://github.com/eProsima/SustainML/releases"><img alt="Releases" src="https://img.shields.io/github/v/release/eProsima/SustainML?sort=semver"/></a>
+    <a href="https://github.com/eProsima/SustainML-Library/actions/workflows/test.yml"><img alt="SustainML Ubuntu CI" src="https://github.com/eProsima/SustainML-Library/actions/workflows/test.yml/badge.svg"/></a>
     <a href="https://github.com/eProsima/SustainML/issues"><img alt="Issues" src="https://img.shields.io/github/issues/eProsima/SustainML.svg"/></a>
     <a href="https://github.com/eProsima/SustainML/network/memberss"><img alt="Forks" src="https://img.shields.io/github/forks/eProsima/SustainML.svg"/></a>
     <a href="https://github.com/eProsima/SustainML/stargazerss"><img alt="Stars" src="https://img.shields.io/github/stars/eProsima/SustainML.svg"/></a>


### PR DESCRIPTION
This PR adds a `Ubuntu CI` status badge on README