### PR TITLE
[23181] Reiterate iterations that are not last

### DIFF
--- a/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
@@ -148,11 +148,13 @@ public:
      * @brief This method reserves a new Task cache in the DB and returns the place
      * where to fill the UserInput entry structure.
      * @param [in] task_id identifier of the previous task from which to iterate
+     * @param [in] last_task_id identifier of the last task from the problem
      * @note It must be called before start_task()
      * @return A pair containing the TaskId and a pointer to the UserInput structure.
      */
     std::pair<types::TaskId, types::UserInput*> prepare_new_iteration(
-            const types::TaskId& task_id);
+            const types::TaskId& task_id,
+            const types::TaskId& last_task_id);
 
     /**
      * @brief This method triggers a new task with a previously prepared task_id and

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -297,12 +297,12 @@ std::pair<types::TaskId, types::UserInput*> OrchestratorNode::prepare_new_task()
 }
 
 std::pair<types::TaskId, types::UserInput*> OrchestratorNode::prepare_new_iteration(
-        const types::TaskId& old_task_id)
-
+        const types::TaskId& old_task_id,
+        const types::TaskId& last_task_id)
 {
     std::pair<types::TaskId, types::UserInput*> output;
     types::TaskId new_task_id(old_task_id);
-    new_task_id.iteration_id(new_task_id.iteration_id() + 1);
+    new_task_id.iteration_id(last_task_id.iteration_id() + 1);
     {
         std::lock_guard<std::mutex> lock(task_db_->get_mutex());
         task_db_->prepare_new_entry_nts(new_task_id, true);
@@ -474,7 +474,7 @@ RetCode_t OrchestratorNode::get_task_data(
     return ret;
 }
 
-RetCode_t OrchestratorNode::get_node_status(
+RetCode_t OrchestratorNode::get_node_status (
         const NodeID& node_id,
         const types::NodeStatus*& status)
 {
@@ -496,7 +496,7 @@ void OrchestratorNode::send_control_command(
     control_writer_->write(cmd.get_impl());
 }
 
-types::ResponseType OrchestratorNode::configuration_request(
+types::ResponseType OrchestratorNode::configuration_request (
         const types::RequestType& req)
 {
     req_res_->write_req(req.get_impl());

--- a/sustainml_cpp/test/blackbox/common/BlackboxTestsOrchestratorNode.cpp
+++ b/sustainml_cpp/test/blackbox/common/BlackboxTestsOrchestratorNode.cpp
@@ -426,7 +426,7 @@ TEST(OrchestratorNode, OrchestratorTaskIteration)
     tonh->prepare_expected_data(test_iteration_data);
 
     //! Prepare a new iteration based on task {1,1}
-    auto iteration_data = orchestrator.prepare_new_iteration({1, 1});
+    auto iteration_data = orchestrator.prepare_new_iteration({1, 1}, {1, 1});
 
     ASSERT_EQ(1, iteration_data.first.problem_id());
     ASSERT_EQ(2, iteration_data.first.iteration_id());

--- a/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
+++ b/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
@@ -355,10 +355,12 @@ class Orchestrator:
             existing_task = self.get_last_task_id()
             if existing_task is not None:
                 if (previous_task.problem_id() == existing_task.problem_id() and
-                        previous_task.iteration_id() + 1 == existing_task.iteration_id()):
-                    print("Task already taken. Using :", utils.string_task(existing_task))
-                    return None
-            pair = self.node_.prepare_new_iteration(previous_task)
+                        previous_task.iteration_id() + 1 <= existing_task.iteration_id()):
+                    pair = self.node_.prepare_new_iteration(previous_task, existing_task)
+                else:
+                    pair = self.node_.prepare_new_iteration(previous_task, previous_task)
+            else:
+                pair = self.node_.prepare_new_iteration(previous_task, previous_task)
         task_id = pair[0]
 
         user_input = pair[1]

--- a/sustainml_modules/test/communication/RequestOrchestratorNode.py
+++ b/sustainml_modules/test/communication/RequestOrchestratorNode.py
@@ -115,10 +115,7 @@ class OrchestratorNode:
         if request_type.node_id() is None or request_type.transaction_id() is None or request_type.configuration() is None:
             return None
         res = self.node_.configuration_request(request_type)
-        if res.success:
-            return res
-        else:
-            return None
+        return res
 
 # Call main in program execution
 if __name__ == '__main__':
@@ -130,7 +127,6 @@ if __name__ == '__main__':
         "transaction_id": 1,
         "configuration": "dummy1"
     })
-    print(f"Response: {res.success()}")
     res = node.send_request({
         "node_id": 1,
         "transaction_id": 1,


### PR DESCRIPTION
This PR change the logic use on reiteration for the case of next iteration_id value already use, meaning the reiteration is done on an id that is not the last one.
Also update wp1 commit version to add metadata prompt improvements and minor fixes.

This PR goes after #72.
 
Depends on:

[PR of wp1](https://github.com/eProsima/sustainml-wp1/pull/12)
