### PR TITLE
[23178] Fix response after same request type with same transaction_id

### DIFF
--- a/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
@@ -87,9 +87,11 @@ public:
     void resume_taking_data();
 
     /**
-     * @brief Method used to get the cv on this class.
+     * @brief Method to wait until a condition is met.
+     * The condition is a lambda function that returns when
+     * it is true.
      */
-    std::condition_variable& get_cv();
+    void wait_until(const std::function<bool()> &condition);
 
 protected:
 

--- a/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
@@ -36,6 +36,8 @@
 #include <fastdds/dds/subscriber/qos/SubscriberQos.hpp>
 #include <fastdds/dds/subscriber/Subscriber.hpp>
 
+using namespace eprosima::fastdds::dds;
+
 namespace sustainml {
 namespace core {
 
@@ -56,6 +58,9 @@ public:
             std::function<void(void*)> callback,
             const char* topicw,
             const char* topicr,
+            DomainParticipant* participant,
+            Publisher* publisher,
+            Subscriber* subscriber,
             void* data);
 
     ~RequestReplier();

--- a/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
@@ -22,6 +22,7 @@
 #include <fastdds/dds/subscriber/DataReaderListener.hpp>
 #include <sustainml_cpp/types/types.hpp>
 #include <types/typesImplPubSubTypes.hpp>
+#include <condition_variable>
 
 #include <fastdds/dds/domain/DomainParticipant.hpp>
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
@@ -75,12 +76,30 @@ public:
     void write_req(
             RequestTypeImpl* req);
 
+    /**
+     * @brief Method used to get the mutex on this class.
+     */
+    std::mutex& get_mutex();
+
+    /**
+     * @brief Method used to set resume_taking_data_ to true.
+     */
+    void resume_taking_data();
+
+    /**
+     * @brief Method used to get the cv on this class.
+     */
+    std::condition_variable& get_cv();
+
 protected:
 
     std::function<void(void*)> callback_;
     const char* topicr_;
     const char* topicw_;
     void* data_;
+    std::mutex mtx_;
+    std::atomic<bool> resume_taking_data_{false};
+    std::condition_variable cv_;
 
     eprosima::fastdds::dds::DomainParticipant* participant_;
 
@@ -131,7 +150,6 @@ private:
 
         RequestReplier* node_;
         size_t matched_;
-
     }
     listener_;
 };

--- a/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/core/RequestReplier.hpp
@@ -91,7 +91,8 @@ public:
      * The condition is a lambda function that returns when
      * it is true.
      */
-    void wait_until(const std::function<bool()> &condition);
+    void wait_until(
+            const std::function<bool()>& condition);
 
 protected:
 

--- a/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
@@ -276,8 +276,6 @@ protected:
     std::atomic_bool terminated_{false};
     std::condition_variable initialization_cv_;
 
-    std::condition_variable cv_;
-
     types::ResponseType res_;
     sustainml::core::RequestReplier* req_res_;
 

--- a/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
+++ b/sustainml_cpp/include/sustainml_cpp/orchestrator/OrchestratorNode.hpp
@@ -302,7 +302,7 @@ protected:
     };
 
     std::condition_variable spin_cv_;
-    std::atomic_bool terminate_;
+    std::atomic_bool terminate_{false};
 
     std::unique_ptr<OrchestratorParticipantListener> participant_listener_;
 

--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -45,8 +45,8 @@ NodeImpl::NodeImpl(
     , participant_(nullptr)
     , publisher_(nullptr)
     , subscriber_(nullptr)
-    , control_listener_(this)
     , req_res_listener_(*new RequestReplyListener())
+    , control_listener_(this)
 {
     if (!init(name))
     {
@@ -63,8 +63,8 @@ NodeImpl::NodeImpl(
     , participant_(nullptr)
     , publisher_(nullptr)
     , subscriber_(nullptr)
-    , control_listener_(this)
     , req_res_listener_(*new RequestReplyListener())
+    , control_listener_(this)
 {
     if (!init(name, opts))
     {
@@ -81,8 +81,8 @@ NodeImpl::NodeImpl(
     , participant_(nullptr)
     , publisher_(nullptr)
     , subscriber_(nullptr)
-    , control_listener_(this)
     , req_res_listener_(req_res_listener)
+    , control_listener_(this)
 {
     req_res_ = new RequestReplier([this, name](void* input)
                     {
@@ -97,7 +97,6 @@ NodeImpl::NodeImpl(
                             req_res_->write_res(res.get_impl());
                         }
                         req_res_->resume_taking_data();
-                        std::cout << "Request Replier finished" << std::endl;    //debug
                     }, "sustainml/response", "sustainml/request", &req_data_);
 
     if (!init(name))
@@ -116,8 +115,8 @@ NodeImpl::NodeImpl(
     , participant_(nullptr)
     , publisher_(nullptr)
     , subscriber_(nullptr)
-    , control_listener_(this)
     , req_res_listener_(req_res_listener)
+    , control_listener_(this)
 {
     req_res_ = new RequestReplier([this, name](void* input)
                     {

--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -96,6 +96,8 @@ NodeImpl::NodeImpl(
                             req_res_listener_.on_configuration_request(req, res);
                             req_res_->write_res(res.get_impl());
                         }
+                        req_res_->resume_taking_data();
+                        std::cout << "Request Replier finished" << std::endl;    //debug
                     }, "sustainml/response", "sustainml/request", &req_data_);
 
     if (!init(name))

--- a/sustainml_cpp/src/cpp/core/RequestReplier.cpp
+++ b/sustainml_cpp/src/cpp/core/RequestReplier.cpp
@@ -34,14 +34,14 @@ RequestReplier::RequestReplier(
         const char* topicr,
         void* data)
     : callback_(callback)
-    , topicw_(topicw)
     , topicr_(topicr)
+    , topicw_(topicw)
     , data_(data)
     , participant_(nullptr)
-    , typeRes_(new ResponseTypeImplPubSubType())
-    , typeReq_(new RequestTypeImplPubSubType())
     , publisher_(nullptr)
     , subscriber_(nullptr)
+    , typeRes_(new ResponseTypeImplPubSubType())
+    , typeReq_(new RequestTypeImplPubSubType())
     , listener_(this)
 {
     auto dpf = DomainParticipantFactory::get_instance();

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -78,7 +78,6 @@ void OrchestratorNode::OrchestratorParticipantListener::on_participant_discovery
         if (reason == eprosima::fastdds::rtps::ParticipantDiscoveryStatus::DISCOVERED_PARTICIPANT &&
                 orchestrator_->node_proxies_[static_cast<uint32_t>(node_id)] == nullptr)
         {
-            EPROSIMA_LOG_INFO(ORCHESTRATOR, "Creating node proxy for " << participant_name << " node");
             ModuleNodeProxyFactory::make_node_proxy(
                 node_id,
                 orchestrator_,
@@ -166,6 +165,7 @@ void OrchestratorNode::destroy()
         DomainParticipantFactory::get_instance()->delete_participant(participant_);
 
         delete task_man_;
+        delete req_res_;
 
         handler_ = nullptr;
         terminated_.store(true);
@@ -534,6 +534,8 @@ void OrchestratorNode::spin()
 void OrchestratorNode::terminate()
 {
     terminate_.store(true);
+    // skip the wait in the replier if any request is pending
+    req_res_->resume_taking_data();
     destroy();
     spin_cv_.notify_all();
 }

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -135,14 +135,16 @@ void OrchestratorNode::destroy()
 {
     if (!terminated_.load())
     {
-        std::lock_guard<std::mutex> lock_proxies(proxies_mtx_);
-        std::lock_guard<std::mutex> lock(mtx_);
-        for (size_t i = 0; i < (size_t)NodeID::MAX; i++)
         {
-            if (node_proxies_[i] != nullptr)
+            std::lock_guard<std::mutex> lock_proxies(proxies_mtx_);
+            std::lock_guard<std::mutex> lock(mtx_);
+            for (size_t i = 0; i < (size_t)NodeID::MAX; i++)
             {
-                delete node_proxies_[i];
-                node_proxies_[i] = nullptr;
+                if (node_proxies_[i] != nullptr)
+                {
+                    delete node_proxies_[i];
+                    node_proxies_[i] = nullptr;
+                }
             }
         }
 

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -78,6 +78,7 @@ void OrchestratorNode::OrchestratorParticipantListener::on_participant_discovery
         if (reason == eprosima::fastdds::rtps::ParticipantDiscoveryStatus::DISCOVERED_PARTICIPANT &&
                 orchestrator_->node_proxies_[static_cast<uint32_t>(node_id)] == nullptr)
         {
+            EPROSIMA_LOG_INFO(ORCHESTRATOR, "Creating node proxy for " << participant_name << " node");
             ModuleNodeProxyFactory::make_node_proxy(
                 node_id,
                 orchestrator_,
@@ -114,11 +115,6 @@ OrchestratorNode::OrchestratorNode(
     task_man_(new TaskManager()),
     participant_listener_(new OrchestratorParticipantListener(this))
 {
-    req_res_ = new core::RequestReplier([this](void* input)
-                    {
-                        this->req_res_->resume_taking_data();
-                    }, "sustainml/request", "sustainml/response", res_.get_impl());
-
     if (!init())
     {
         EPROSIMA_LOG_ERROR(ORCHESTRATOR, "Orchestrator initialization Failed");
@@ -273,6 +269,11 @@ bool OrchestratorNode::init()
         EPROSIMA_LOG_ERROR(ORCHESTRATOR, "Error creating the subscriber");
         return false;
     }
+
+    req_res_ = new core::RequestReplier([this](void* input)
+                    {
+                        this->req_res_->resume_taking_data();
+                    }, "sustainml/request", "sustainml/response", participant_, pub_, sub_, res_.get_impl());
 
     initialized_.store(true);
     initialization_cv_.notify_one();

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -117,12 +117,6 @@ OrchestratorNode::OrchestratorNode(
 {
     req_res_ = new core::RequestReplier([this](void* input)
                     {
-                        ResponseTypeImpl* in = static_cast<ResponseTypeImpl*>(input);
-
-                        {
-                            std::lock_guard<std::mutex> lock(this->mtx_);
-                            this->res_ = *in;
-                        }
                         this->cv_.notify_all();
                     }, "sustainml/request", "sustainml/response", res_.get_impl());
 
@@ -505,8 +499,7 @@ types::ResponseType OrchestratorNode::configuration_request (
             {
                 return res_.node_id() == req.node_id() && res_.transaction_id() == req.transaction_id();
             });
-    types::ResponseType res = res_;
-    return res;
+    return res_;
 }
 
 void OrchestratorNode::spin()


### PR DESCRIPTION
This PR change node_id and transaction_selection to be decided on the backend, being transparent for the frontend. 
Also, this PR fix some duplications on the code.

This PR goes after #73. 