### PR TITLE
[23298] Fix `max_instances` 500 not set on baselines_writer for allowing more than 10 results on one table

### DIFF
--- a/sustainml_cpp/src/cpp/orchestrator/ModuleNodeProxy.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/ModuleNodeProxy.cpp
@@ -167,9 +167,14 @@ ModuleNodeProxy::ModuleNodeProxy(
             return;
         }
 
+        DataWriterQos dwqos = DATAWRITER_QOS_DEFAULT;
+        dwqos.resource_limits().max_instances = 500;
+        dwqos.resource_limits().max_samples_per_instance = 1;
+        dwqos.durability().kind = eprosima::fastdds::dds::TRANSIENT_LOCAL_DURABILITY_QOS;
+
         baseline_writer_ = orchestrator_->pub_->create_datawriter(
             baseline_topic_,
-            DATAWRITER_QOS_DEFAULT,
+            dwqos,
             nullptr);
 
         if (baseline_writer_ == nullptr)

--- a/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
+++ b/sustainml_cpp/src/cpp/orchestrator/OrchestratorNode.cpp
@@ -256,7 +256,7 @@ bool OrchestratorNode::init()
 
     user_input_writer_ = pub_->create_datawriter(user_input_topic_, dwqos);
 
-    if (user_input_topic_ == nullptr)
+    if (user_input_writer_ == nullptr)
     {
         EPROSIMA_LOG_ERROR(ORCHESTRATOR, "Error creating the user input writer");
         return false;

--- a/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
+++ b/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
@@ -97,6 +97,7 @@ class OrchestratorNodeHandle(cpp_OrchestratorNodeHandle):
                     if num_outputs > 1:
                         print(f"Reiterating for multiple outputs")
                         user_json = self.orchestrator.get_user_input_data(task_id)
+                        user_json.get('extra_data', {})['goal'] = self.orchestrator.get_model_metadata_task_data(task_id).get('metadata', None) # Get the last model goal
                         user_json.get('extra_data', {})['num_outputs'] = num_outputs - 1
                         user_json['previous_iteration'] = task_id.iteration_id()
                         user_json.get('extra_data', {})['previous_problem_id'] = task_id.problem_id()


### PR DESCRIPTION
This PR add qos  `max_instance = 500` for `baselines_writer` for allowing the backend to keep working after the 10th iteration on the same problem.

Also, this PR corrects a condition variable error, and add the pass of the model goal obtained on the first iteration when reiterate or ask for multiple results and the goal was not select as input.

Goes after #79.