### PR TITLE
[23047] Free up disk space in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,6 +38,20 @@ jobs:
           - ubuntu-22.04
 
     steps:
+      - name: Free Disk Space
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
+
       - name: Sync repository
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -62,12 +62,6 @@ jobs:
           packages: colcon-common-extensions colcon-mixin vcstool gcovr==5
           upgrade: false
 
-      - name: Install Python documentation dependencies
-        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
-        with:
-          requirements_file_name: ${{ github.workspace }}/src/sustainml_lib/sustainml_docs/requirements.txt
-          upgrade: false
-
       - name: Install Python submodules dependencies
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:


### PR DESCRIPTION
This PR frees up space in the CI by:

* Removing dependencies from `sustainml_docs` since it is neither built nor installed in the multiplatform job.
* Adds an additional first step to clean up disk space.