### PR TITLE
[23596] Add control and stop task while running

### DIFF
--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -47,6 +47,7 @@ NodeImpl::NodeImpl(
     , subscriber_(nullptr)
     , req_res_listener_(*new RequestReplyListener())
     , control_listener_(this)
+    , stop_task_callback_(nullptr)
 {
     if (!init(name))
     {
@@ -65,6 +66,7 @@ NodeImpl::NodeImpl(
     , subscriber_(nullptr)
     , req_res_listener_(*new RequestReplyListener())
     , control_listener_(this)
+    , stop_task_callback_(nullptr)
 {
     if (!init(name, opts))
     {
@@ -83,6 +85,7 @@ NodeImpl::NodeImpl(
     , subscriber_(nullptr)
     , req_res_listener_(req_res_listener)
     , control_listener_(this)
+    , stop_task_callback_(nullptr)
 {
     if (!init(name))
     {
@@ -102,6 +105,7 @@ NodeImpl::NodeImpl(
     , subscriber_(nullptr)
     , req_res_listener_(req_res_listener)
     , control_listener_(this)
+    , stop_task_callback_(nullptr)
 {
     if (!init(name, opts))
     {
@@ -335,6 +339,25 @@ void NodeImpl::publish_node_status()
     }
 }
 
+void NodeImpl::stop_current_task(const TaskIdImpl& task_id)
+{
+    if (stop_task_callback_)
+    {
+        EPROSIMA_LOG_INFO(NODE, "Stopping task " << task_id.problem_id() << "." << task_id.iteration_id());
+        stop_task_callback_(task_id);
+    }
+    else
+    {
+        EPROSIMA_LOG_WARNING(NODE, "No stop task callback registered for task " << task_id.problem_id() << "." << task_id.iteration_id());
+    }
+}
+
+void NodeImpl::register_stop_task_callback(std::function<void(const TaskIdImpl&)> callback)
+{
+    stop_task_callback_ = callback;
+    EPROSIMA_LOG_INFO(NODE, "Stop task callback registered successfully");
+}
+
 void NodeImpl::terminate()
 {
     terminate_.store(true);
@@ -403,6 +426,8 @@ void NodeImpl::NodeControlListener::on_data_available(
             break;
             case CmdTask::STOP_TASK:
             cmd_task_str = "STOP_TASK";
+            // Call stop_task() here if needed
+            node_->stop_current_task(control.task_id());
             break;
             case CmdTask::RESET_TASK:
             cmd_task_str = "RESET_TASK";
@@ -423,11 +448,6 @@ void NodeImpl::NodeControlListener::on_data_available(
               << " para task=" << control.task_id().problem_id() << "."
               << control.task_id().iteration_id()
               << std::endl;
-
-        if (static_cast<int32_t>(control.cmd_task()) == static_cast<int32_t>(CmdTask::STOP_TASK))
-        {
-            // node_->stop_task(control.task_id());    // TODO stop_task
-        }
     }
 }
 

--- a/sustainml_cpp/src/cpp/core/NodeImpl.cpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.cpp
@@ -198,9 +198,16 @@ bool NodeImpl::init(
     }
 
     //! Initialize common topics
-    initialize_subscription(common::TopicCollection::get()[common::Topics::NODE_CONTROL].first.c_str(),
+    std::string name_no_node = name.substr(0, name.size() - std::string("_NODE").size());
+    std::string filter_expr   = "target_node = %0";
+std::vector<std::string> filter_params{ std::string("'") + name_no_node + "'" };
+    std::cout << "Node name without _NODE: " << name_no_node << std::endl;
+    initialize_subscription_content_filter(common::TopicCollection::get()[common::Topics::NODE_CONTROL].first.c_str(),
             common::TopicCollection::get()[common::Topics::NODE_CONTROL].second.c_str(),
-            &control_listener_, opts);
+            filter_expr.c_str(),
+            filter_params,
+            &control_listener_,
+            opts);
 
     initialize_publication(common::TopicCollection::get()[common::Topics::NODE_STATUS].first.c_str(),
             common::TopicCollection::get()[common::Topics::NODE_STATUS].second.c_str(),
@@ -243,6 +250,46 @@ bool NodeImpl::initialize_subscription(
     }
 
     DataReader* reader = subscriber_->create_datareader(topic, opts.rqos, listener);
+
+    if (reader == nullptr)
+    {
+        return false;
+    }
+
+    topics_.emplace_back(topic);
+    readers_.emplace_back(reader);
+
+    return true;
+}
+
+bool NodeImpl::initialize_subscription_content_filter(
+        const char* topic_name,
+        const char* type_name,
+        const char* filter_expression,
+        const std::vector<std::string>& filter_parameters,
+        eprosima::fastdds::dds::DataReaderListener* listener,
+        const Options& opts)
+{
+    Topic* topic = participant_->create_topic(topic_name, type_name, TOPIC_QOS_DEFAULT);
+
+    if (topic == nullptr)
+    {
+        return false;
+    }
+
+    for (const auto& parameter : filter_parameters)
+    {
+        std::cout << "Content Filter Parameter: " << parameter << std::endl;
+    }
+    std::string filter_name = std::string(topic_name) + "_cf";
+    ContentFilteredTopic* filter_topic = participant_->create_contentfilteredtopic(filter_name.c_str(), topic, filter_expression, filter_parameters);
+
+    if (filter_topic == nullptr)
+    {
+        return false;
+    }
+
+    DataReader* reader = subscriber_->create_datareader(filter_topic, opts.rqos, listener);
 
     if (reader == nullptr)
     {
@@ -310,6 +357,7 @@ void NodeImpl::NodeControlListener::on_subscription_matched(
         eprosima::fastdds::dds::DataReader* reader,
         const eprosima::fastdds::dds::SubscriptionMatchedStatus& status)
 {
+    std::cout << "[CONTROL] NodeControl subscription matched" << std::endl;
 
     EPROSIMA_LOG_INFO(NODE, "NodeControl Reader Suscription status");
 
@@ -336,7 +384,51 @@ void NodeImpl::NodeControlListener::on_subscription_matched(
 void NodeImpl::NodeControlListener::on_data_available(
         eprosima::fastdds::dds::DataReader* reader)
 {
+    std::cout << "[CONTROL] NodeControl data available" << std::endl;
     EPROSIMA_LOG_INFO(NODE, "NodeStatus has a new status ");
+    // NodeControl data
+    NodeControlImpl control;
+    eprosima::fastdds::dds::SampleInfo info;
+
+    while (reader->take_next_sample(&control, &info) == RETCODE_OK)
+    {
+        if (! info.valid_data)
+            continue;
+
+        std::string cmd_task_str;
+        switch (control.cmd_task())
+        {
+            case CmdTask::NO_CMD_TASK:
+            cmd_task_str = "NO_CMD_TASK";
+            break;
+            case CmdTask::STOP_TASK:
+            cmd_task_str = "STOP_TASK";
+            break;
+            case CmdTask::RESET_TASK:
+            cmd_task_str = "RESET_TASK";
+            break;
+            case CmdTask::PREEMPT_TASK:
+            cmd_task_str = "PREEMPT_TASK";
+            break;
+            case CmdTask::TERMINATE_TASK:
+            cmd_task_str = "TERMINATE_TASK";
+            break;
+            default:
+            cmd_task_str = "UNKNOWN";
+            break;
+        }
+
+        std::cout << "[CONTROL] recibido cmd=" << cmd_task_str
+              << " de " << control.source_node()
+              << " para task=" << control.task_id().problem_id() << "."
+              << control.task_id().iteration_id()
+              << std::endl;
+
+        if (static_cast<int32_t>(control.cmd_task()) == static_cast<int32_t>(CmdTask::STOP_TASK))
+        {
+            // node_->stop_task(control.task_id());    // TODO stop_task
+        }
+    }
 }
 
 } // namespace core

--- a/sustainml_cpp/src/cpp/core/NodeImpl.hpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.hpp
@@ -160,6 +160,18 @@ protected:
      */
     void publish_node_status();
 
+    /**
+     * @brief Stops the current task execution
+     * @param task_id The task ID to stop
+     */
+    void stop_current_task(const TaskIdImpl& task_id);
+    
+    /**
+     * @brief Register a callback to handle task stopping
+     * @param callback Function to call when a task needs to be stopped
+     */
+    void register_stop_task_callback(std::function<void(const TaskIdImpl&)> callback);
+
     Node* node_;
 
     std::shared_ptr<Dispatcher> dispatcher_;
@@ -211,6 +223,9 @@ private:
     bool init(
             const std::string& name,
             const Options& opts = Options());
+
+    // Callback function pointer for task stopping
+    std::function<void(const TaskIdImpl&)> stop_task_callback_;
 
     class NodeControlListener : public eprosima::fastdds::dds::DataReaderListener
     {

--- a/sustainml_cpp/src/cpp/core/NodeImpl.hpp
+++ b/sustainml_cpp/src/cpp/core/NodeImpl.hpp
@@ -112,7 +112,7 @@ protected:
      * @brief Starts a new subscription (DataReader) in the
      * given topic.
      *
-     * @param topic The topic name
+     * @param topic_name The topic name
      * @param type_name The type name
      * @param listener Listener object inheriting from DataReaderListener
      * @param opts Options object with the Subscription configuration
@@ -120,6 +120,25 @@ protected:
     bool initialize_subscription(
             const char* topic_name,
             const char* type_name,
+            eprosima::fastdds::dds::DataReaderListener* listener,
+            const Options& opts);
+
+    /**
+     * @brief Starts a new subscription (DataReader) in the
+     * given content filter topic.
+     *
+     * @param topic_name The topic name
+     * @param type_name The type name
+     * @param listener Listener object inheriting from DataReaderListener
+     * @param filter_expression The content filter expression
+     * @param filter_parameters The content filter parameters
+     * @param opts Options object with the Subscription configuration
+     */
+    bool initialize_subscription_content_filter(
+            const char* topic_name,
+            const char* type_name,
+            const char* filter_expression,
+            const std::vector<std::string>& filter_parameters,
             eprosima::fastdds::dds::DataReaderListener* listener,
             const Options& opts);
 

--- a/sustainml_modules/sustainml_modules/sustainml-wp5/backend_node.py
+++ b/sustainml_modules/sustainml_modules/sustainml-wp5/backend_node.py
@@ -130,6 +130,20 @@ def results_args():
 
     return jsonify({utils.string_node(node_id): orchestrator.get_results(node_id, task_id)}), 200
 
+# Cancels an iteration based on the provided problem_id and iteration_id.
+@server.route('/cancel', methods=['POST'])
+def cancel():
+    data = request.get_json(force=True)
+    pid = data.get("problem_id")
+    iid = data.get("iteration_id")
+    if pid is None or iid is None:
+        return jsonify({"error": "Either problem_id or iteration_id not selected"}), 400
+    ok = orchestrator.cancel_iteration(pid, iid)
+    if ok:
+        return jsonify({"status": "cancelled"}), 200
+    else:
+        return jsonify({"status": "not_found"}), 404
+
 # Flask server shutdown route
 @server.route('/shutdown', methods=['GET'])
 def shutdown():

--- a/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
+++ b/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/orchestrator_node.py
@@ -116,6 +116,7 @@ class Orchestrator:
         self.node_ = cpp_OrchestratorNode(self.handler_)
         self._txn_lock = threading.Lock()
         self._txn_counter = 0
+        self._cancelled = set()
 
     # Proxy method to run the node
     def run(self):
@@ -126,6 +127,27 @@ class Orchestrator:
     def terminate(self):
 
         self.node_.terminate()
+
+    def cancel_iteration(self, problem_id: int, iteration_id: int) -> bool:
+
+        print(f"Canceling iteration {iteration_id} for problem {problem_id}")
+        tid = sustainml_swig.TaskId()
+        tid.problem_id(problem_id)
+        tid.iteration_id(iteration_id)
+        key = (problem_id, iteration_id)
+        self._cancelled.add(key)
+
+        ctrl = sustainml_swig.NodeControl()
+        ctrl.task_id(tid)
+        ctrl.source_node(utils.string_node(utils.node_id.ORCHESTRATOR.value))
+        ctrl.cmd_task(utils.cmd_task.STOP_TASK.value)
+        ctrl.cmd_node(utils.cmd_node.RESET_NODE.value)  # Reset or doing nothing? WIP
+        ctrl.target_node(utils.string_node(utils.node_id.ML_MODEL_METADATA.value))
+        print(f"Target node: {utils.string_node(utils.node_id.ML_MODEL_METADATA.value)}")
+        self.node_.send_control_command(ctrl)
+        # 3) borra la entrada en C++
+        # return self.node_.delete_task(tid)    # WIP. Delate the last that was stopped
+        return True
 
     def get_last_task_id(self):
         return self.handler_.last_task_id
@@ -402,6 +424,7 @@ class Orchestrator:
         hw_req = extra.get('hardware_required', utils.default_hw_requirement)
         mem_footprint = extra.get('max_memory_footprint', utils.default_mem_footprint)
         goal = extra.get('goal')
+        metric = extra.get('metric', None)
         model_selected = extra.get('model_selected', None)
         num_outputs = extra.get('num_outputs')
         model_restrains = extra.get('model_restrains', [])
@@ -417,6 +440,7 @@ class Orchestrator:
         extra_data = {'hardware_required': hw_req,
                       'max_memory_footprint': mem_footprint,
                       'goal': goal,
+                      'metric': metric,
                       'model_selected': model_selected,
                       'num_outputs': num_outputs,
                       'model_restrains': model_restrains,

--- a/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/utils.py
+++ b/sustainml_modules/sustainml_modules/sustainml-wp5/orchestrator_node/utils.py
@@ -40,6 +40,23 @@ class node_status(Enum):
     TERMINATING = 5
     UNKNOWN = 6
 
+class cmd_task(Enum):
+    NO_CMD_TASK    = 0
+    START_TASK     = 1
+    STOP_TASK      = 2
+    RESET_TASK     = 3
+    PREEMPT_TASK   = 4
+    TERMINATE_TASK = 5
+    UNKNOWN        = 6
+
+class cmd_node(Enum):
+    NO_CMD_NODE     = 0
+    START_NODE      = 1
+    STOP_NODE       = 2
+    RESET_NODE      = 3
+    TERMINATE_NODE  = 4
+    UNKNOWN         = 5
+
 # Node status from integer to string
 def string_status(status):
     if status == node_status.INACTIVE.value:          # NODE_INACTIVE

--- a/sustainml_py/sustainml_py/AsyncTaskManager.py
+++ b/sustainml_py/sustainml_py/AsyncTaskManager.py
@@ -1,0 +1,207 @@
+# Copyright 2025 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""AsyncTaskManager for handling cancellable async tasks in SustainML nodes."""
+
+import asyncio
+import threading
+import logging
+from typing import Dict, Callable, Optional
+
+
+class AsyncTaskManager:
+    """Manages async tasks with cancellation support for SustainML nodes."""
+
+    def __init__(self):
+        self.running_tasks: Dict[str, asyncio.Task] = {}
+        self.stop_events: Dict[str, asyncio.Event] = {}
+        self.loop: Optional[asyncio.AbstractEventLoop] = None
+        self.loop_thread: Optional[threading.Thread] = None
+        self._setup_event_loop()
+
+    def _setup_event_loop(self):
+        """Setup a dedicated event loop for async operations."""
+        def run_loop():
+            self.loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(self.loop)
+            self.loop.run_forever()
+
+        self.loop_thread = threading.Thread(target=run_loop, daemon=True)
+        self.loop_thread.start()
+
+        # Wait for loop to be ready
+        while self.loop is None:
+            threading.Event().wait(0.01)
+
+    def _get_task_key(self, task_id) -> str:
+        """Convert task_id to string key following SustainML patterns."""
+        if hasattr(task_id, 'problem_id') and hasattr(task_id, 'iteration_id'):
+            return f"{task_id.problem_id()}_{task_id.iteration_id()}"
+        return str(task_id)
+
+    async def _wrapped_callback(self, original_callback: Callable, stop_event: asyncio.Event, *args, **kwargs):
+        """Wrapper for the original callback that can be cancelled."""
+        try:
+            # Check if we should stop before starting
+            if stop_event.is_set():
+                logging.info("Task was stopped before execution")
+                return
+
+            # If the callback is async, await it with cancellation support
+            if asyncio.iscoroutinefunction(original_callback):
+                # Create a task that can be cancelled
+                callback_task = asyncio.create_task(original_callback(*args, **kwargs))
+                stop_task = asyncio.create_task(stop_event.wait())
+
+                # Wait for either the callback to complete or stop signal
+                done, pending = await asyncio.wait(
+                    [callback_task, stop_task],
+                    return_when=asyncio.FIRST_COMPLETED
+                )
+
+                # Cancel any pending tasks
+                for task in pending:
+                    task.cancel()
+
+                if stop_task in done:
+                    logging.info("Task was stopped during execution")
+                    callback_task.cancel()
+                    return
+
+                # Return the result if callback completed
+                if callback_task in done:
+                    return callback_task.result()
+            else:
+                # For sync callbacks, run in executor with periodic stop checks
+                def sync_wrapper():
+                    if stop_event.is_set():
+                        return None
+                    return original_callback(*args, **kwargs)
+
+                return await self.loop.run_in_executor(None, sync_wrapper)
+
+        except asyncio.CancelledError:
+            logging.info("Task was cancelled")
+            raise
+        except Exception as e:
+            logging.error(f"Error in task execution: {e}")
+            raise
+
+    def start_task(self, task_id, callback: Callable, *args, **kwargs) -> bool:
+        """Start a new async task."""
+        if self.loop is None:
+            return False
+
+        task_key = self._get_task_key(task_id)
+
+        # Stop existing task with same ID if any
+        self.stop_task(task_id)
+
+        # Create stop event for this task
+        stop_event = asyncio.Event()
+
+        # Schedule the stop event creation in the event loop
+        asyncio.run_coroutine_threadsafe(
+            self._create_stop_event(task_key, stop_event),
+            self.loop
+        )
+
+        # Schedule the task in the event loop
+        future = asyncio.run_coroutine_threadsafe(
+            self._wrapped_callback(callback, stop_event, *args, **kwargs),
+            self.loop
+        )
+
+        # Convert future to task for easier management
+        def on_done(fut):
+            # Clean up when task completes
+            self.running_tasks.pop(task_key, None)
+            self.stop_events.pop(task_key, None)
+
+        future.add_done_callback(on_done)
+        self.running_tasks[task_key] = future
+
+        return True
+
+    async def _create_stop_event(self, task_key: str, stop_event: asyncio.Event):
+        """Create and store stop event in the event loop."""
+        self.stop_events[task_key] = stop_event
+
+    def stop_task(self, task_id) -> bool:
+        """Stop a running task."""
+        task_key = self._get_task_key(task_id)
+
+        # Signal the task to stop
+        if task_key in self.stop_events:
+            # Schedule the stop event to be set in the event loop
+            if self.loop and not self.loop.is_closed():
+                asyncio.run_coroutine_threadsafe(
+                    self._set_stop_event(task_key),
+                    self.loop
+                )
+
+        # Cancel the running task if it exists
+        if task_key in self.running_tasks:
+            task = self.running_tasks[task_key]
+            task.cancel()
+            return True
+
+        return False
+
+    async def _set_stop_event(self, task_key: str):
+        """Set the stop event for a task."""
+        if task_key in self.stop_events:
+            self.stop_events[task_key].set()
+
+    def is_task_running(self, task_id) -> bool:
+        """Check if a task is currently running."""
+        task_key = self._get_task_key(task_id)
+        return task_key in self.running_tasks
+
+    def stop_all_tasks(self):
+        """Stop all running tasks."""
+        for task_key in list(self.running_tasks.keys()):
+            # Create a dummy task_id object following the pattern
+            parts = task_key.split('_')
+            problem_id = int(parts[0]) if len(parts) > 0 else 0
+            iteration_id = int(parts[1]) if len(parts) > 1 else 0
+
+            # Use sustainml_swig to create proper TaskId
+            try:
+                import sustainml_swig
+                task_id = sustainml_swig.TaskId()
+                task_id.problem_id(problem_id)
+                task_id.iteration_id(iteration_id)
+                self.stop_task(task_id)
+            except ImportError:
+                # Fallback if sustainml_swig not available
+                pass
+
+    def shutdown(self):
+        """Shutdown the async task manager."""
+        self.stop_all_tasks()
+        if self.loop and not self.loop.is_closed():
+            self.loop.call_soon_threadsafe(self.loop.stop)
+        if self.loop_thread and self.loop_thread.is_alive():
+            self.loop_thread.join(timeout=1.0)
+
+# Global instance following SustainML pattern
+_task_manager = None
+
+def get_task_manager() -> AsyncTaskManager:
+    """Get the global task manager instance."""
+    global _task_manager
+    if _task_manager is None:
+        _task_manager = AsyncTaskManager()
+    return _task_manager

--- a/sustainml_py/sustainml_py/__init__.py
+++ b/sustainml_py/sustainml_py/__init__.py
@@ -13,3 +13,7 @@
 # limitations under the License.
 
 """SustainML Python Bindings"""
+
+from .AsyncTaskManager import AsyncTaskManager, get_task_manager
+
+__all__ = ['AsyncTaskManager', 'get_task_manager']

--- a/sustainml_py/sustainml_py/nodes/MLModelNode.py
+++ b/sustainml_py/sustainml_py/nodes/MLModelNode.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 """SustainML Client Node API specification."""
 
+import asyncio
+import logging
 from sustainml_swig import MLModelTaskListener as cpp_MLModelTaskListener
 from sustainml_swig import MLModelNode as cpp_MLModelNode
 from sustainml_swig import RequestReplyListener as cpp_RequestReplyListener
@@ -20,12 +22,15 @@ from sustainml_swig import RequestReplyListener as cpp_RequestReplyListener
 
 from sustainml_swig import MLModel, NodeStatus, MLModelMetadata, HWConstraints, AppRequirements, HWResource, CO2Footprint, RequestType, ResponseType
 
+from ..AsyncTaskManager import get_task_manager
+
 class MLModelTaskListener(cpp_MLModelTaskListener):
 
     def __init__(self,
                  callback):
 
         self.callback_ = callback
+        self.task_manager = get_task_manager()
 
         # Parent class constructor
         super().__init__()
@@ -44,6 +49,22 @@ class MLModelTaskListener(cpp_MLModelTaskListener):
 
         """ Invoke user callback """
         self.callback_(ml_model_metadata, app_requirements, hw_constraints, ml_model_baseline, hw_baseline, carbonfootprint_baseline, node_status, ml_model)
+        task_id = ml_model.task_id()
+
+        async def async_callback():
+            if asyncio.iscoroutinefunction(self.callback_):
+                await self.callback_(ml_model_metadata, app_requirements, hw_constraints,
+                                   ml_model_baseline, hw_baseline, carbonfootprint_baseline,
+                                   node_status, ml_model)
+            else:
+                self.callback_(ml_model_metadata, app_requirements, hw_constraints,
+                              ml_model_baseline, hw_baseline, carbonfootprint_baseline,
+                              node_status, ml_model)
+
+        # Start the task with cancellation support
+        success = self.task_manager.start_task(task_id, async_callback)
+        if not success:
+            logging.warning(f"Failed to start async task for {task_id.problem_id()}.{task_id.iteration_id()}")
 
 class RequestReplyListener(cpp_RequestReplyListener):
 
@@ -82,15 +103,39 @@ class MLModelNode:
 
         self.listener_ = MLModelTaskListener(callback)
         self.listener_service_ = RequestReplyListener(service_callback)
+        self.task_manager = get_task_manager()
 
         self.node_ = cpp_MLModelNode(self.listener_, self.listener_service_)
 
+        # Register the stop callback with the C++ node
+        self._register_stop_callback()
+
+    def _register_stop_callback(self):
+        """Register the stop callback with the underlying C++ implementation."""
+        def stop_callback(task_id):
+            logging.info(f"Stopping MLModel task {task_id.problem_id()}.{task_id.iteration_id()}")
+            self.task_manager.stop_task(task_id)
+
+        # Register the callback with the C++ node if the method is available
+        if hasattr(self.node_, 'register_stop_task_callback'):
+            self.node_.register_stop_task_callback(stop_callback)
+        else:
+            logging.warning("C++ node does not support stop task callback registration")
+
     # Proxy method to run the node
     def spin(self):
-
         self.node_.spin()
 
-    # Proxy method to manually terminate
-    def terminate():
+    def stop_task(self, task_id):
+        """Public method to stop a specific task."""
+        return self.task_manager.stop_task(task_id)
 
+    def stop_all_tasks(self):
+        """Stop all running tasks."""
+        self.task_manager.stop_all_tasks()
+
+    # Proxy method to manually terminate
+    @staticmethod
+    def terminate():
+        get_task_manager().shutdown()
         cpp_MLModelNode.terminate()

--- a/sustainml_swig/src/swig/sustainml_swig/core/NodeImpl.i
+++ b/sustainml_swig/src/swig/sustainml_swig/core/NodeImpl.i
@@ -1,0 +1,50 @@
+%{
+#include <functional>
+#include "sustainml_cpp/core/NodeImpl.hpp"
+%}
+
+// Expose the stop task functionality
+%extend sustainml::core::NodeImpl {
+    void register_stop_task_callback(PyObject* callback) {
+        if (callback && PyCallable_Check(callback)) {
+            Py_INCREF(callback);
+
+            auto cpp_callback = [callback](const TaskIdImpl& task_id) {
+                PyGILState_STATE gstate = PyGILState_Ensure();
+
+                try {
+                    // Create Python TaskId object using SWIG conversion
+                    PyObject* py_task_id = SWIG_NewPointerObj(
+                        const_cast<TaskIdImpl*>(&task_id),
+                        SWIGTYPE_p_TaskIdImpl,
+                        0
+                    );
+
+                    PyObject* result = PyObject_CallFunctionObjArgs(callback, py_task_id, NULL);
+
+                    if (result) {
+                        Py_DECREF(result);
+                    } else {
+                        PyErr_Print();
+                    }
+
+                    Py_DECREF(py_task_id);
+                } catch (...) {
+                    PyErr_Print();
+                }
+
+                PyGILState_Release(gstate);
+            };
+
+            $self->register_stop_task_callback(cpp_callback);
+        }
+    }
+}
+
+%extend sustainml::core::MLModelNode {
+    void register_stop_task_callback(PyObject* callback) {
+        if (callback && PyCallable_Check(callback)) {
+            this->get_node_impl()->register_stop_task_callback(callback);
+        }
+    }
+}


### PR DESCRIPTION
This PR apply changes add the connection logic from backend to frontend to use node_control for stopping execution of a task.
Also add content-filter to the node_control topic.

It's still on going, asyncio to stop task is not yet fully used.

Goes after
- #84 