### PR TITLE
[#23611] Upgraded runner image to `ubuntu-24.04`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -243,7 +243,7 @@ jobs:
 # UNCRUSTIFY
 
   uncrustify:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
 
       - name: Uncrustify


### PR DESCRIPTION
Upgraded runner image to ```ubuntu-24.04```. Now using ```Uncrustify-0.78.1_f``` the new default _uncrustify_ version for this image